### PR TITLE
Updating the UMM Repository with the More changes from develop (#36)

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -6,6 +6,9 @@ on:
         description: If set, docker img is built and tagged accordingly
         required: false
   push:
+    branches: [ "main", "develop" ]
+    tags: [ "v*.*.*" ]
+  pull_request:
 
 jobs:
   Compile-and-Test:
@@ -41,7 +44,10 @@ jobs:
   Build-and-Deploy:
     name: "Build and Push Docker Image"
     runs-on: ubuntu-latest
-    if: contains(fromJSON('["main", "develop", "redlink", "staging"]'), github.ref_name) || github.event.inputs.dockerTag != ''
+    if: |
+      contains(fromJSON('["main", "develop"]'), github.ref_name) || 
+      github.event.inputs.dockerTag != '' ||
+      startsWith(github.ref, 'refs/tags/v')
     needs:
       - Compile-and-Test
     steps:
@@ -57,6 +63,12 @@ jobs:
           if [ "$BRANCH" == "$MAIN_BRANCH" ]; then
             TAGS="latest,$TAGS"
           fi
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            MAJOR_MINOR="${VERSION%.*}"
+            MAJOR="${VERSION%%.*}"
+            TAGS="$VERSION,$MAJOR_MINOR,$MAJOR"
+          fi
           if [ -n "$EVENT_PARAM" ]; then
             TAGS="$EVENT_PARAM"
           fi
@@ -69,16 +81,16 @@ jobs:
       - name: Build JIB container and publish to GitHub Packages
         run:
           ./mvnw -B -U
-            --no-transfer-progress
-            clean verify jib:build
-            -Drevision=${{github.run_number}}
-            -Dchangelist=
-            -Dsha1=.${GITHUB_SHA:0:7}
-            -Dquick
-            -Ddocker.namespace=${DOCKER_NAMESPACE,,}
-            -Djib.to.tags=${TAGS}
-            -Djib.to.auth.username=${{ github.actor }}
-            -Djib.to.auth.password=${{ secrets.GITHUB_TOKEN }}
+          --no-transfer-progress
+          clean verify jib:build
+          -Drevision=${{github.run_number}}
+          -Dchangelist=
+          -Dsha1=.${GITHUB_SHA:0:7}
+          -Dquick
+          -Ddocker.namespace=${DOCKER_NAMESPACE,,}
+          -Djib.to.tags=${TAGS}
+          -Djib.to.auth.username=${{ github.actor }}
+          -Djib.to.auth.password=${{ secrets.GITHUB_TOKEN }}
         env:
           DOCKER_NAMESPACE: ghcr.io/${{ github.repository_owner }}
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,37 @@ After that, you need to start the Data Gateway using the `standalone` spring-pro
 The default settings in the `application.yaml` are set to use these local services. Please note that these services bind
 to the same ports as those for the Studymanager Backend, so running both at the same time will lead to conflicts.
 
+## Deployment & Tagging Strategy
+
+This repository uses Git tags to manage releases and Docker image deployments.
+
+### Tag Format
+
+Tags should follow the semantic versioning format: `v<Major>.<Minor>.<Patch>`
+Example: `v1.0.1`
+
+### Automated Deployment
+
+- **Branch Pushes**: Pushes to `main`, `develop` branches automatically trigger a Docker image
+  build and push to the GitHub Container Registry (GHCR), tagged with the branch name.
+- **Pull Requests**: The "Test and Compile" workflow runs on all pull requests to ensure code quality.
+- **Tag Pushes**: Pushing a tag matching the `v*.*.*` pattern triggers a build and push to GHCR. The image will be
+  tagged with the version (e.g., `1.0.1`) and the full tag (e.g., `v1.0.1`).
+- **Manual**: Workflows can be triggered manually via `workflow_dispatch` with an optional custom Docker tag.
+
+## Configuration
+
+The Data Gateway can be configured using environment variables. The following table lists the most important
+configuration
+properties:
+
+| Property                          | Environment Variable                                | Default Value                           | Description                                                                                                        |
+|-----------------------------------|-----------------------------------------------------|-----------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `more.gateway.baseUrl`            | `BASE_URL`                                          | -                                       | The base URL of the Data Gateway.                                                                                  |
+| `more.login-token.hash-algorithm` | `LOGIN_TOKEN_HASH_ALGORITHM`                        | `SHA-256`                               | The hash algorithm used to store and verify login tokens. Must be a valid `java.security.MessageDigest` algorithm. |
+| `elastic.host`                    | `ELASTIC_HOST`                                      | `localhost`                             | The host of the Elasticsearch instance.                                                                            |
+| `elastic.port`                    | `ELASTIC_PORT`                                      | `9200`                                  | The port of the Elasticsearch instance.                                                                            |
+| `spring.datasource.url`           | `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DBNAME` | `jdbc:postgresql://localhost:5432/more` | The JDBC URL of the PostgreSQL database.                                                                           |
 
 [SM-Backend]: https://github.com/MORE-Platform/more-studymanager-backend
 

--- a/TimeSeriesAPI.yaml
+++ b/TimeSeriesAPI.yaml
@@ -5,8 +5,8 @@ info:
     This describes the datastructures of the TimeSeries stored in ElasticSearch
   version: v1
 
-servers: []
-paths: {}
+servers: [ ]
+paths: { }
 
 components:
   schemas:
@@ -19,11 +19,11 @@ components:
           type: string
           format: uuid
         participantId:
-          $ref: '#/components/schemas/Id'
+          $ref: 'src/main/resources/openapi/BaseComponents.yaml#/components/schemas/Id'
         studyId:
-          $ref: '#/components/schemas/Id'
+          $ref: 'src/main/resources/openapi/BaseComponents.yaml#/components/schemas/Id'
         moduleId:
-          $ref: '#/components/schemas/Id'
+          $ref: 'src/main/resources/openapi/BaseComponents.yaml#/components/schemas/Id'
         moduleType:
           type: string
         dataType:
@@ -84,7 +84,7 @@ components:
           maximum: 90
         longitude:
           description:
-            geographical longitude east or west of Greenwich, England, in `degrees`. 
+            geographical longitude east or west of Greenwich, England, in `degrees`.
             Negative values indicate `West`.
           type: number
           format: double
@@ -115,6 +115,3 @@ components:
       required: [ datetime ]
       externalDocs:
         url: https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_date-time
-
-    Id:
-      type: string

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
     </properties>
 
     <scm>
-        <connection>https://github.com/MORE-Platform/more-dsb-gateway.git</connection>
-        <developerConnection>git@github.com:MORE-Platform/more-dsb-gateway.git</developerConnection>
-        <url>https://github.com/MORE-Platform/more-dsb-gateway</url>
+        <connection>https://github.com/MORE-Platform/more-data-gateway.git</connection>
+        <developerConnection>git@github.com:MORE-Platform/more-data-gateway.git</developerConnection>
+        <url>https://github.com/MORE-Platform/more-data-gateway</url>
         <tag>HEAD</tag>
     </scm>
 
@@ -370,6 +370,32 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>participant-portal-api</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/openapi/ParticipantPortalAPI.yaml</inputSpec>
+                            <output>${project.build.directory}/generated-sources/participant-portal</output>
+                            <apiPackage>io.redlink.more.data.api.participant.v1.webservices</apiPackage>
+                            <modelPackage>io.redlink.more.data.api.participant.v1.model</modelPackage>
+                            <modelNameSuffix>DTO</modelNameSuffix>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>observation-execution-api</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/openapi/ObservationExecutionAPI.yaml</inputSpec>
+                            <output>${project.build.directory}/generated-sources/observation-execution</output>
+                            <apiPackage>io.redlink.more.data.api.execution.v1.webservices</apiPackage>
+                            <modelPackage>io.redlink.more.data.api.execution.v1.model</modelPackage>
+                            <modelNameSuffix>DTO</modelNameSuffix>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>garmin-api</id>
                         <goals>
                             <goal>generate</goal>
@@ -447,6 +473,32 @@
                             </configOptions>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>limesurvey-api</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/openapi/LimeSurveyRemoteControlAPI.yaml</inputSpec>
+                            <output>${project.build.directory}/generated-sources/limesurvey</output>
+                            <generatorName>java</generatorName>
+                            <library>resttemplate</library>
+                            <packageName>io.redlink.more.data.limesurvey</packageName>
+                            <apiPackage>io.redlink.more.data.limesurvey.client</apiPackage>
+                            <modelPackage>io.redlink.more.data.limesurvey.model</modelPackage>
+                            <generateSupportingFiles>true</generateSupportingFiles>
+                            <addCompileSourceRoot>true</addCompileSourceRoot>
+                            <configOptions>
+                                <dateLibrary>java8</dateLibrary>
+                                <useJakartaEe>true</useJakartaEe>
+                                <serializationLibrary>jackson</serializationLibrary>
+                                <removeOperationIdPrefix>true</removeOperationIdPrefix>
+                                <modelMutable>false</modelMutable>
+                                <useBeanValidation>false</useBeanValidation>
+                                <openApiNullable>false</openApiNullable>
+                            </configOptions>
+                        </configuration>
+                    </execution>
                  </executions>
                 <configuration>
                     <generatorName>spring</generatorName>
@@ -458,7 +510,7 @@
                     <apiPackage>io.redlink.more.data.api.app.v1.webservices</apiPackage>
 
                     <generateModels>true</generateModels>
-                    <apiPackage>io.redlink.more.data.api.app.v1.model</apiPackage>
+                    <modelPackage>io.redlink.more.data.api.app.v1.model</modelPackage>
 
                     <generateApiTests>false</generateApiTests>
                     <generateApiDocumentation>true</generateApiDocumentation>

--- a/src/main/java/io/redlink/more/data/configuration/LoginTokenProperties.java
+++ b/src/main/java/io/redlink/more/data/configuration/LoginTokenProperties.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.configuration;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Component
+@ConfigurationProperties(prefix = "more.login-token")
+public class LoginTokenProperties {
+
+    private String hashAlgorithm = "SHA-256";
+
+    public String getHashAlgorithm() {
+        return hashAlgorithm;
+    }
+
+    public void setHashAlgorithm(String hashAlgorithm) {
+        this.hashAlgorithm = hashAlgorithm;
+    }
+
+    @PostConstruct
+    public void validateConfiguration() {
+        try {
+            MessageDigest.getInstance(getHashAlgorithm());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Invalid hash algorithm: " + getHashAlgorithm(), e);
+        }
+    }
+}

--- a/src/main/java/io/redlink/more/data/configuration/SecurityConfig.java
+++ b/src/main/java/io/redlink/more/data/configuration/SecurityConfig.java
@@ -58,6 +58,12 @@ public class SecurityConfig {
                             .permitAll();
                     req.requestMatchers("/api/v1/signup")
                             .permitAll();
+                    req.requestMatchers("/api/v1/login/**")
+                            .permitAll();
+                    req.requestMatchers("/api/v1/execution/callback", "/api/v1/execution/callback/end.htm")
+                            .permitAll();
+                    req.requestMatchers("/participant-portal/api/v1/login/**")
+                            .permitAll();
                     //External Data Gateway
                     req.requestMatchers("/api/v1/external/bulk")
                             .permitAll();
@@ -76,6 +82,8 @@ public class SecurityConfig {
                             .permitAll();
                     // all other apis require credentials
                     req.requestMatchers("/api/v1/**")
+                            .authenticated();
+                    req.requestMatchers("/participant-portal/api/v1/**")
                             .authenticated();
                     // actuator only from localhost
                     req.requestMatchers(

--- a/src/main/java/io/redlink/more/data/configuration/SessionConfiguration.java
+++ b/src/main/java/io/redlink/more/data/configuration/SessionConfiguration.java
@@ -13,7 +13,6 @@ import org.springframework.security.jackson2.SecurityJackson2Modules;
 
 @Configuration
 public class SessionConfiguration {
-
     @Bean
     public RedisSerializer<Object> springSessionRedisSerializer() {
         return new GenericJackson2JsonRedisSerializer(sessionObjectMapper());

--- a/src/main/java/io/redlink/more/data/controller/ConfigurationApiV1Controller.java
+++ b/src/main/java/io/redlink/more/data/controller/ConfigurationApiV1Controller.java
@@ -11,10 +11,12 @@ import io.redlink.more.data.api.app.v1.webservices.ConfigurationApi;
 import io.redlink.more.data.configuration.AuthenticationFacade;
 import io.redlink.more.data.controller.transformer.NotificationServiceTransformer;
 import io.redlink.more.data.controller.transformer.StudyTransformer;
+import io.redlink.more.data.model.CompletedData;
 import io.redlink.more.data.model.GatewayUserDetails;
 import io.redlink.more.data.service.GatewayUserDetailService;
+import io.redlink.more.data.service.ObservationExecutionService;
 import io.redlink.more.data.service.PushNotificationService;
-import io.redlink.more.data.service.RegistrationService;
+import io.redlink.more.data.service.StudyService;
 import io.redlink.more.data.util.LoggingUtils;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -31,14 +33,17 @@ public class ConfigurationApiV1Controller implements ConfigurationApi {
 
     private final AuthenticationFacade authenticationFacade;
 
-    private final RegistrationService registrationService;
-
     private final PushNotificationService pushNotificationService;
 
-    public ConfigurationApiV1Controller(AuthenticationFacade authenticationFacade, RegistrationService registrationService, PushNotificationService pushNotificationService) {
+    private final StudyService studyService;
+
+    private final ObservationExecutionService observationExecutionService;
+
+    public ConfigurationApiV1Controller(AuthenticationFacade authenticationFacade, PushNotificationService pushNotificationService, StudyService studyService, ObservationExecutionService observationExecutionService) {
         this.authenticationFacade = authenticationFacade;
-        this.registrationService = registrationService;
         this.pushNotificationService = pushNotificationService;
+        this.studyService = studyService;
+        this.observationExecutionService = observationExecutionService;
     }
 
     @Override
@@ -46,17 +51,11 @@ public class ConfigurationApiV1Controller implements ConfigurationApi {
         final GatewayUserDetails userDetails = authenticationFacade
                 .assertAuthority(GatewayUserDetailService.APP_ROLE);
         try (LoggingUtils.LoggingContext ctx = LoggingUtils.createContext(userDetails.getRoutingInfo())) {
-            var study = registrationService.loadStudyByRoutingInfo(userDetails.getRoutingInfo());
-            if (study.isEmpty()) {
-                return ResponseEntity.notFound().build();
-            }
-            var participantObservationProperties = registrationService
-                    .getParticipantObservationSeeds(userDetails.getRoutingInfo().studyId(), userDetails.getRoutingInfo().participantId())
-                    .stream()
-                    .toList();
-            return ResponseEntity.of(
-                    study.map(s -> StudyTransformer.toDTO(s, participantObservationProperties))
-            );
+            var studyData = studyService.getStudy(userDetails.getRoutingInfo());
+            List<CompletedData> completedData = observationExecutionService.getCompletedData(userDetails.getRoutingInfo());
+            return studyData.map(s -> StudyTransformer.toDTO(s.getLeft(), s.getRight(), completedData))
+                    .map(ResponseEntity::ok)
+                    .orElseGet(() -> ResponseEntity.notFound().build());
         }
     }
 

--- a/src/main/java/io/redlink/more/data/controller/ExternalDataApiV1Controller.java
+++ b/src/main/java/io/redlink/more/data/controller/ExternalDataApiV1Controller.java
@@ -29,6 +29,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -90,7 +91,10 @@ public class ExternalDataApiV1Controller implements ExternalDataApi {
             return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(e.getMessage());
         } catch (BadRequestException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-        } catch (Exception e) {
+        } catch (IOException e) {
+            LOG.error("Error storing data:", e);
+            return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body("Could not store data!");
+        } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }

--- a/src/main/java/io/redlink/more/data/controller/GlobalControllerExceptionHandler.java
+++ b/src/main/java/io/redlink/more/data/controller/GlobalControllerExceptionHandler.java
@@ -1,0 +1,72 @@
+package io.redlink.more.data.controller;
+
+import io.redlink.more.data.api.app.v1.model.ErrorDTO;
+import io.redlink.more.data.controller.transformer.ErrorTransformer;
+import io.redlink.more.data.exception.BadRequestException;
+import io.redlink.more.data.exception.ForbiddenException;
+import io.redlink.more.data.exception.NotAuthorizedException;
+import io.redlink.more.data.exception.NotFoundException;
+import io.redlink.more.data.exception.RegistrationNotPossibleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalControllerExceptionHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GlobalControllerExceptionHandler.class);
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<Void> handleForbidden(ForbiddenException e) {
+        LOG.warn("Forbidden: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<Void> handleNotFound(NotFoundException e) {
+        LOG.warn("Not Found: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+
+    @ExceptionHandler(NotAuthorizedException.class)
+    public ResponseEntity<Void> handleNotAuthorized(NotAuthorizedException e) {
+        LOG.warn("Not Authorized: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Void> handleBadRequest(BadRequestException e) {
+        LOG.warn("Bad Request: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Void> handleAccessDenied(AccessDeniedException e) {
+        LOG.warn("Access Denied: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+
+    @ExceptionHandler(RegistrationNotPossibleException.class)
+    public ResponseEntity<ErrorDTO> handleRegistrationError(RegistrationNotPossibleException rnpe) {
+        LOG.warn("Registration not possible: [{}] {}", rnpe.getErrorCode(), rnpe.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ErrorTransformer.toDTO(rnpe));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorDTO> handleError(RuntimeException ex) {
+        LOG.error("Unexpected runtime error: {}", ex.getMessage(), ex);
+        return ResponseEntity.internalServerError()
+                .body(ErrorTransformer.toDTO(ex));
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Void> handleIllegalState(IllegalStateException ex) {
+        LOG.error("Illegal state: {}", ex.getMessage());
+        return ResponseEntity.internalServerError().build();
+    }
+}

--- a/src/main/java/io/redlink/more/data/controller/ObservationExecutionController.java
+++ b/src/main/java/io/redlink/more/data/controller/ObservationExecutionController.java
@@ -1,0 +1,176 @@
+package io.redlink.more.data.controller;
+
+import io.redlink.more.data.api.execution.v1.webservices.ExecutionApi;
+import io.redlink.more.data.configuration.AuthenticationFacade;
+import io.redlink.more.data.exception.BadRequestException;
+import io.redlink.more.data.exception.ForbiddenException;
+import io.redlink.more.data.exception.NotAuthorizedException;
+import io.redlink.more.data.exception.NotFoundException;
+import io.redlink.more.data.exception.RegistrationNotPossibleException;
+import io.redlink.more.data.model.GatewayUserDetails;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.model.StudyParticipantUserDetails;
+import io.redlink.more.data.service.ObservationExecutionService;
+import io.redlink.more.data.service.StudyService;
+import io.redlink.more.data.util.DateTimeUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping(value = "/api/v1/execution", produces = MediaType.APPLICATION_JSON_VALUE)
+public class ObservationExecutionController implements ExecutionApi {
+    private static final Logger LOG = LoggerFactory.getLogger(ObservationExecutionController.class);
+    private final AuthenticationFacade authenticationFacade;
+    private final StudyService studyService;
+    private final ObservationExecutionService observationExecutionService;
+
+    public ObservationExecutionController(AuthenticationFacade authenticationFacade, StudyService studyService, ObservationExecutionService observationExecutionService) {
+        this.authenticationFacade = authenticationFacade;
+        this.studyService = studyService;
+        this.observationExecutionService = observationExecutionService;
+    }
+
+    @Override
+    public ResponseEntity<Void> execObservation(String observationId, String scheduleStart, String scheduleEnd, String redirect) {
+        try {
+            final Instant start = DateTimeUtils.parseInstant(scheduleStart);
+            final Instant end = DateTimeUtils.parseInstant(scheduleEnd);
+            final RoutingInfo routingInfo = getRoutingInfo()
+                    .orElseThrow(() -> new AccessDeniedException("No credentials found!"));
+
+            var url = observationExecutionService.executeObservation(observationId, start, end, routingInfo, redirect);
+
+            if (url.isEmpty()) {
+                url = Optional.of(UriComponentsBuilder.fromUriString(fallbackTarget())
+                        .replaceQueryParam("status", HttpStatus.CONFLICT.value())
+                        .build().toUri());
+            }
+            return ResponseEntity.status(HttpStatus.FOUND).location(url.get()).build();
+        } catch (RuntimeException e) {
+            LOG.error("Error executing observation {}: {}", observationId, e.getMessage(), e);
+            String target = (redirect != null && !redirect.isBlank()) ? redirect : fallbackTarget();
+            URI redirectUrl = UriComponentsBuilder.fromUriString(target)
+                    .queryParam("status", mapToStatus(e))
+                    .build().toUri();
+            return ResponseEntity.status(HttpStatus.FOUND).location(redirectUrl).build();
+        }
+    }
+
+
+    @Override
+    public ResponseEntity<String> callback() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        Map<String, String> params = new HashMap<>();
+        request.getParameterMap().forEach((key, value) -> params.put(key, value[0]));
+
+        Map<String, String> pathVars = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        if (pathVars != null) {
+            params.putAll(pathVars);
+        }
+
+        UriComponentsBuilder builder = ServletUriComponentsBuilder.fromCurrentRequestUri()
+                .path("/end.htm");
+        params.forEach((k, v) -> {
+            if (k.equalsIgnoreCase("savedId")) {
+                builder.replaceQueryParam("savedid", v);
+            } else {
+                builder.replaceQueryParam(k, v);
+            }
+        });
+
+        URI redirectUrl = builder.build().toUri();
+
+        LOG.info("process callback: pathVars: {}, params: {}", pathVars, params);
+
+        int status = HttpStatus.OK.value();
+
+        try {
+            var redirect = observationExecutionService.processCallback(params);
+
+            if (redirect.isPresent()) {
+                UriComponentsBuilder redirectBuilder = UriComponentsBuilder.fromUri(redirect.get());
+                params.forEach((k, v) -> {
+                    if (k.equalsIgnoreCase("savedId")) {
+                        redirectBuilder.replaceQueryParam("savedid", v);
+                    } else {
+                        redirectBuilder.replaceQueryParam(k, v);
+                    }
+                });
+                redirectUrl = redirectBuilder.build().toUri();
+            }
+        } catch (RuntimeException e) {
+            LOG.error("Error processing callback: {}", e.getMessage(), e);
+            status = mapToStatus(e);
+        }
+
+        redirectUrl = UriComponentsBuilder.fromUri(redirectUrl)
+                .replaceQueryParam("status", status)
+                .build().toUri();
+
+        LOG.info("Redirecting participant {} to url `{}`", getRoutingInfo().orElse(null), redirectUrl);
+        return ResponseEntity.status(HttpStatus.FOUND).location(redirectUrl).build();
+    }
+
+    @Override
+    public ResponseEntity<String> callbackEndHtm() {
+        String html = "<html><body><h1>Completed! Thank you!</h1></body></html>";
+        return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(html);
+    }
+
+
+    private Optional<RoutingInfo> getRoutingInfo() {
+        Authentication authentication = authenticationFacade.getAuthentication();
+        if (authentication == null) {
+            LOG.warn("No authentication found!");
+            return Optional.empty();
+        }
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof GatewayUserDetails userDetails) {
+            return Optional.ofNullable(userDetails.getRoutingInfo());
+        } else if (principal instanceof StudyParticipantUserDetails participantDetails) {
+            var ref = participantDetails.getStudyParticipantReference();
+            return studyService.getRoutingInfo(ref.studyId(), ref.participantId());
+        }
+        return Optional.empty();
+    }
+
+    private String fallbackTarget() {
+        return ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/api/v1/execution/callback/end.htm")
+                .toUriString();
+    }
+
+    private int mapToStatus(Exception e) {
+        if (e instanceof ForbiddenException || e instanceof AccessDeniedException || e instanceof IllegalArgumentException) {
+            return HttpStatus.FORBIDDEN.value();
+        } else if (e instanceof NotFoundException) {
+            return HttpStatus.NOT_FOUND.value();
+        } else if (e instanceof NotAuthorizedException) {
+            return HttpStatus.UNAUTHORIZED.value();
+        } else if (e instanceof BadRequestException) {
+            return HttpStatus.BAD_REQUEST.value();
+        } else if (e instanceof RegistrationNotPossibleException) {
+            return HttpStatus.CONFLICT.value();
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR.value();
+    }
+}

--- a/src/main/java/io/redlink/more/data/controller/RegistrationApiV1Controller.java
+++ b/src/main/java/io/redlink/more/data/controller/RegistrationApiV1Controller.java
@@ -5,13 +5,10 @@ package io.redlink.more.data.controller;
 
 import io.redlink.more.data.api.app.v1.model.ApiKeyDTO;
 import io.redlink.more.data.api.app.v1.model.AppConfigurationDTO;
-import io.redlink.more.data.api.app.v1.model.ErrorDTO;
-import io.redlink.more.data.api.app.v1.model.ObservationConsentDTO;
 import io.redlink.more.data.api.app.v1.model.StudyConsentDTO;
 import io.redlink.more.data.api.app.v1.model.StudyDTO;
 import io.redlink.more.data.api.app.v1.webservices.RegistrationApi;
 import io.redlink.more.data.configuration.AuthenticationFacade;
-import io.redlink.more.data.controller.transformer.ErrorTransformer;
 import io.redlink.more.data.controller.transformer.StudyTransformer;
 import io.redlink.more.data.exception.RegistrationNotPossibleException;
 import io.redlink.more.data.model.ApiCredentials;
@@ -21,13 +18,12 @@ import io.redlink.more.data.model.ParticipantObservationSeed;
 import io.redlink.more.data.properties.MoreProperties;
 import io.redlink.more.data.service.GatewayUserDetailService;
 import io.redlink.more.data.service.RegistrationService;
-import org.apache.commons.lang3.StringUtils;
+import io.redlink.more.data.service.StudyService;
+import io.redlink.more.data.util.ParticipantUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -48,11 +44,14 @@ public class RegistrationApiV1Controller implements RegistrationApi {
 
     private final AuthenticationFacade authenticationFacade;
 
+    private final StudyService studyService;
 
-    public RegistrationApiV1Controller(MoreProperties moreProperties, RegistrationService registrationService, AuthenticationFacade authenticationFacade) {
+
+    public RegistrationApiV1Controller(MoreProperties moreProperties, RegistrationService registrationService, AuthenticationFacade authenticationFacade, StudyService studyService) {
         this.moreProperties = moreProperties;
         this.registrationService = registrationService;
         this.authenticationFacade = authenticationFacade;
+        this.studyService = studyService;
     }
 
     @Override
@@ -61,8 +60,9 @@ public class RegistrationApiV1Controller implements RegistrationApi {
         if (study.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
-        List<ParticipantObservationSeed> seeds = study.get().active() ? registrationService.getParticipantObservationSeeds(study.get().studyId(), study.get().participant().id()) : Collections.emptyList();
-        var studyDto = StudyTransformer.toDTO(study.get(), seeds);
+        List<ParticipantObservationSeed> seeds = study.get().active() ? studyService.getParticipantObservationSeeds(study.get().studyId(), study.get().participant().id()) : Collections.emptyList();
+
+        var studyDto = StudyTransformer.toDTO(study.get(), seeds, Collections.emptyList());
         return ResponseEntity.ok()
                 // For better debugging: return the token for chaining
                 .header("More-Registration-Token", moreRegistrationToken)
@@ -72,9 +72,9 @@ public class RegistrationApiV1Controller implements RegistrationApi {
 
     @Override
     public ResponseEntity<AppConfigurationDTO> registerForStudy(String moreRegistrationToken, StudyConsentDTO studyConsentDTO) {
-        final ParticipantConsent consent = convert(studyConsentDTO);
+        final ParticipantConsent consent = ParticipantUtils.convert(studyConsentDTO);
 
-        if (registrationService.validateConsent(consent)) {
+        if (consent.accepted()) {
             return ResponseEntity.of(
                     registrationService.register(moreRegistrationToken, consent)
                             .map(RegistrationApiV1Controller::convert)
@@ -86,20 +86,6 @@ public class RegistrationApiV1Controller implements RegistrationApi {
         }
 
         throw RegistrationNotPossibleException.noConsentGiven();
-    }
-
-    @ExceptionHandler(RegistrationNotPossibleException.class)
-    public ResponseEntity<ErrorDTO> handleRegistrationError(RegistrationNotPossibleException rnpe) {
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .header("X-Info", "[%S] %s".formatted(rnpe.getErrorCode(), rnpe.getMessage()))
-                .body(ErrorTransformer.toDTO(rnpe));
-    }
-
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ErrorDTO> handleError(RuntimeException ex) {
-        return ResponseEntity.internalServerError()
-                .header("X-Info", ex.getMessage())
-                .body(ErrorTransformer.toDTO(ex));
     }
 
     @Override
@@ -122,45 +108,6 @@ public class RegistrationApiV1Controller implements RegistrationApi {
                     .normalize()
                     .toUri();
         }
-    }
-
-    private static ParticipantConsent convert(StudyConsentDTO dto) {
-        return new ParticipantConsent(
-                dto.getConsent(),
-                obfuscate(dto.getDeviceId()),
-                dto.getConsentInfoMD5(),
-                null,
-                convert(dto.getObservations())
-        );
-    }
-
-    /**
-     * Device-ID has the format "[MODEL]#[SERIAL], we obfuscate to [MODEL]#[SERIAL:0:6]...[SERIAL:-6:-0]
-     */
-    private static String obfuscate(String string) {
-        final String unknown = "unknown";
-        if (string == null) return unknown;
-
-        final int keepChars = 6;
-        final int delim = string.indexOf('#');
-        return "%s#%s...%s".formatted(
-                StringUtils.defaultIfEmpty(StringUtils.left(string, delim), unknown),
-                StringUtils.mid(string, delim + 1, keepChars),
-                StringUtils.right(string, keepChars)
-        );
-    }
-
-    private static List<ParticipantConsent.ObservationConsent> convert(List<ObservationConsentDTO> observations) {
-        return observations.stream()
-                .map(RegistrationApiV1Controller::convert)
-                .toList();
-    }
-
-    private static ParticipantConsent.ObservationConsent convert(ObservationConsentDTO observations) {
-        return new ParticipantConsent.ObservationConsent(
-                Integer.parseInt(observations.getObservationId()),
-                null
-        );
     }
 
     private static ApiKeyDTO convert(ApiCredentials credentials) {

--- a/src/main/java/io/redlink/more/data/controller/participantportal/ParticipantPortalController.java
+++ b/src/main/java/io/redlink/more/data/controller/participantportal/ParticipantPortalController.java
@@ -1,0 +1,223 @@
+package io.redlink.more.data.controller.participantportal;
+
+import io.redlink.more.data.api.participant.v1.model.StudyConsentDTO;
+import io.redlink.more.data.api.participant.v1.model.StudyDTO;
+import io.redlink.more.data.api.participant.v1.webservices.AuthorizationApi;
+import io.redlink.more.data.api.participant.v1.webservices.ConfigurationApi;
+import io.redlink.more.data.controller.transformer.ParticipantPortalTransformer;
+import io.redlink.more.data.exception.NotAuthorizedException;
+import io.redlink.more.data.model.CompletedData;
+import io.redlink.more.data.model.DataHealth;
+import io.redlink.more.data.model.ObservationDataState;
+import io.redlink.more.data.model.ParticipantConsent;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.model.StudyParticipantUserDetails;
+import io.redlink.more.data.service.ApplicationAccessService;
+import io.redlink.more.data.service.DataHealthService;
+import io.redlink.more.data.service.ObservationExecutionService;
+import io.redlink.more.data.service.StudyService;
+import io.redlink.more.data.util.ParticipantUtils;
+import io.redlink.more.data.util.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+@Controller
+@RestController
+@RequestMapping(value = "/participant-portal/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
+public class ParticipantPortalController implements AuthorizationApi, ConfigurationApi {
+    private static final Logger LOG = LoggerFactory.getLogger(ParticipantPortalController.class);
+
+    private static final Collection<String> ALLOWED_STUDY_STATES = Set.of("active", "paused", "preview", "paused-preview");
+
+    private final ApplicationAccessService applicationAccessService;
+    private final StudyService studyService;
+    private final DataHealthService dataHealthService;
+    private final ObservationExecutionService observationExecutionService;
+
+    ParticipantPortalController(
+            ApplicationAccessService applicationAccessService,
+            StudyService studyService,
+            DataHealthService dataHealthService,
+            ObservationExecutionService observationExecutionService) {
+        this.applicationAccessService = applicationAccessService;
+        this.studyService = studyService;
+        this.dataHealthService = dataHealthService;
+        this.observationExecutionService = observationExecutionService;
+    }
+
+    @Override
+    public ResponseEntity<Void> participantLogin(Long moreStudyId, String moreUserDataReference, String moreLoginCode) {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        final HttpServletRequest request;
+        if (requestAttributes instanceof ServletRequestAttributes) {
+            request = ((ServletRequestAttributes) requestAttributes).getRequest();
+        } else {
+            throw new IllegalStateException("Request is not a ServletRequest");
+        }
+
+        final String decodedToken;
+        try {
+            decodedToken = StringUtils.base64Decode(moreLoginCode);
+        } catch (RuntimeException e) {
+            LOG.warn("Could not decode more login code", e);
+            throw new NotAuthorizedException("Login Code is not valid");
+        }
+
+        RoutingInfo routingInfo = applicationAccessService.validateLogin(moreStudyId, moreUserDataReference, decodedToken)
+                .filter(ri -> validateStudyState(ri.studyId()))
+                .orElseThrow(NotAuthorizedException::new);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(
+                routingInfo.studyId(), routingInfo.participantId(),
+                null);
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        );
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(auth);
+        SecurityContextHolder.setContext(context);
+
+        HttpSession session = request.getSession(true);
+        session.setAttribute(
+                HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
+                context
+        );
+        // change session id to prevent session fixation
+        request.changeSessionId();
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> participantLogout() {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (!(requestAttributes instanceof ServletRequestAttributes servletRequestAttributes)) {
+            throw new IllegalStateException("Request is not a ServletRequest");
+        }
+
+        HttpServletRequest request = servletRequestAttributes.getRequest();
+        HttpSession session = request.getSession(false);
+
+        if (session != null) {
+            session.removeAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
+            session.invalidate();
+        }
+
+        SecurityContextHolder.clearContext();
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> acceptConsent(StudyConsentDTO studyConsentDTO) {
+        RoutingInfo routingInfo = validateRoutingInfo()
+                .orElseThrow(NotAuthorizedException::new);
+        if (applicationAccessService.hasConsent(routingInfo)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+        final ParticipantConsent consent = ParticipantUtils.convert(studyConsentDTO);
+        applicationAccessService.validateAndStoreConsent(routingInfo, consent);
+        return ResponseEntity.noContent().build();
+    }
+
+
+    @Override
+    public ResponseEntity<StudyDTO> retrieveConsentData() {
+        RoutingInfo routingInfo = validateRoutingInfo()
+                .orElseThrow(NotAuthorizedException::new);
+        if (applicationAccessService.hasConsent(routingInfo)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+        var studyData = studyService.getStudy(routingInfo);
+        return studyData
+                .map(studyListPair ->
+                        ResponseEntity.ok(ParticipantPortalTransformer.toDTO(studyListPair.getLeft(), studyListPair.getRight())))
+                .orElseGet(() ->
+                        ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+    }
+
+    @Override
+    public ResponseEntity<StudyDTO> getStudyConfiguration() {
+        RoutingInfo routingInfo = validateRoutingInfo()
+                .orElseThrow(NotAuthorizedException::new);
+
+        var studyData = studyService.getStudy(routingInfo)
+                .filter(sd -> sd.getLeft().active() || "paused".equals(sd.getLeft().studyState()));
+        if (studyData.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        var studyDTO = ParticipantPortalTransformer.toDTO(studyData.get().getLeft(), studyData.get().getRight());
+
+        List<CompletedData> completedData = observationExecutionService.getCompletedData(routingInfo);
+        //add the dataHealth information to the studyDTO (Not done in Transformer as this need calls to the dataHealthService)
+        studyDTO.getObservations().forEach(observation -> {
+            var observationNonMissingData = completedData.stream().filter(d -> Objects.equals(d.observationId(), observation.getObservationId())).toList();
+            observation.getSchedule().forEach(observationSchedule -> {
+                DataHealth dataHealth;
+                if (!observationNonMissingData.isEmpty()
+                        && observationSchedule.getStart() != null
+                        && observationSchedule.getEnd() != null
+                        && observationNonMissingData.stream().anyMatch(nonMissingData1 ->
+                        !observationSchedule.getStart().isBefore(nonMissingData1.scheduleStart())
+                                && !observationSchedule.getEnd().isAfter(nonMissingData1.scheduleEnd()))) {
+                    dataHealth = new DataHealth(true, ObservationDataState.COMPLETE);
+                } else if (observationSchedule.getStart() != null
+                        && observationSchedule.getStart().isBefore(Instant.now())) {
+                    dataHealth = dataHealthService.checkDataHealth(
+                            routingInfo.studyId(),
+                            routingInfo.participantId(),
+                            Integer.parseInt(observation.getObservationId()), //ObservationId in the API is a String :(
+                            observationSchedule.getStart());
+                    LOG.debug(
+                            "check dataHealth[study:{}, participant:{}, observation:{}, start:{}] -> {}",
+                            routingInfo.studyId(),
+                            routingInfo.participantId(),
+                            observation.getObservationId(),
+                            observationSchedule.getStart(),
+                            dataHealth);
+                } else {
+                    dataHealth = null; //no need to check for existing data if the observation has not yet started
+                }
+                observationSchedule.setDataHealth(ParticipantPortalTransformer.toDataHealStateDto(dataHealth));
+            });
+        });
+
+        return ResponseEntity.ok(studyDTO);
+    }
+
+
+    private Optional<RoutingInfo> validateRoutingInfo() {
+        var studyParticipant = StudyParticipantUserDetails.getCurrent().getStudyParticipantReference();
+        return studyService.getRoutingInfo(studyParticipant.studyId(), studyParticipant.participantId())
+                .filter(routingInfo -> validateStudyState(routingInfo.studyId()));
+    }
+
+    private boolean validateStudyState(long studyId) {
+        return studyService.getStudyState(studyId)
+                .filter(ALLOWED_STUDY_STATES::contains)
+                .isPresent();
+    }
+}

--- a/src/main/java/io/redlink/more/data/controller/transformer/ParticipantPortalTransformer.java
+++ b/src/main/java/io/redlink/more/data/controller/transformer/ParticipantPortalTransformer.java
@@ -1,0 +1,140 @@
+package io.redlink.more.data.controller.transformer;
+
+import io.redlink.more.data.api.participant.v1.model.ContactInfoDTO;
+import io.redlink.more.data.api.participant.v1.model.DataHealthStateDTO;
+import io.redlink.more.data.api.participant.v1.model.ObservationDTO;
+import io.redlink.more.data.api.participant.v1.model.ObservationScheduleDTO;
+import io.redlink.more.data.api.participant.v1.model.SimpleParticipantDTO;
+import io.redlink.more.data.api.participant.v1.model.StudyDTO;
+import io.redlink.more.data.model.Contact;
+import io.redlink.more.data.model.DataHealth;
+import io.redlink.more.data.model.Observation;
+import io.redlink.more.data.model.ParticipantObservationSeed;
+import io.redlink.more.data.model.SimpleParticipant;
+import io.redlink.more.data.model.Study;
+import io.redlink.more.data.util.SchedulerUtils;
+import org.apache.commons.lang3.Range;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public final class ParticipantPortalTransformer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ParticipantPortalTransformer.class);
+
+    public static StudyDTO toDTO(Study study, List<ParticipantObservationSeed> seeds) {
+        return new StudyDTO()
+                .active(study.active())
+                .studyTitle(study.title())
+                .participantInfo(study.participantInfo())
+                .consentInfo(study.consentInfo())
+                .finishText(study.finishText())
+                .studyState(toStudyStateDTO(study.studyState()))
+                .participant(toDTO(study.participant()))
+                .contact(toDTO(study.contact()))
+                .start(study.startDate())
+                .end(study.endDate())
+                .observations(toDTO(seeds, study.observations(),
+                        Optional.ofNullable(study.participant()).map(SimpleParticipant::start).orElse(null),
+                        Optional.ofNullable(study.participant()).map(SimpleParticipant::end).orElse(null)))
+                .version(BaseTransformers.toVersionTag(study.modified()));
+    }
+
+    private static StudyDTO.StudyStateEnum toStudyStateDTO(String studyState) {
+        if (studyState == null) {
+            return StudyDTO.StudyStateEnum.CLOSED;
+        }
+        return switch (studyState) {
+            case "active" -> StudyDTO.StudyStateEnum.ACTIVE;
+            case "preview" -> StudyDTO.StudyStateEnum.PREVIEW;
+            case "paused", "paused-preview" -> StudyDTO.StudyStateEnum.PAUSED;
+            default -> StudyDTO.StudyStateEnum.CLOSED;
+        };
+    }
+
+    public static SimpleParticipantDTO toDTO(SimpleParticipant participant) {
+        if (participant == null) {
+            return null;
+        }
+        return new SimpleParticipantDTO()
+                .alias(participant.alias());
+    }
+
+    public static ContactInfoDTO toDTO(Contact contact) {
+        if (contact == null) {
+            return null;
+        }
+        return new ContactInfoDTO()
+                .institute(contact.institute())
+                .person(contact.person())
+                .email(contact.email())
+                .phoneNumber(contact.phoneNumber());
+    }
+
+    public static List<ObservationDTO> toDTO(List<ParticipantObservationSeed> participantObservationSeeds, List<Observation> observations, Instant start, Instant end) {
+        return observations.stream().map(o -> {
+            var seed = participantObservationSeeds.stream()
+                    .filter(s -> s.observationId() == o.observationId())
+                    .findFirst()
+                    .orElse(null);
+            return ParticipantPortalTransformer.toDTO(seed, o, start, end);
+        }).toList();
+    }
+
+    public static ObservationDTO toDTO(ParticipantObservationSeed participantObservationSeed, Observation observation, Instant start, Instant end) {
+        ObservationDTO dto = new ObservationDTO()
+                .observationId(String.valueOf(observation.observationId()))
+                .observationType(observation.type())
+                .observationTitle(observation.title())
+                .participantInfo(observation.participantInfo())
+                ._configuration(observation.properties())
+                .version(BaseTransformers.toVersionTag(observation.modified()))
+                .hidden(observation.hidden())
+                .noSchedule(observation.noSchedule())
+                .reminder(observation.reminder());
+        if (observation.observationSchedule() != null && start != null) {
+            dto.schedule(SchedulerUtils
+                    .parseToObservationSchedules(
+                            participantObservationSeed,
+                            observation.observationSchedule(),
+                            start,
+                            end)
+                    .stream()
+                    .map(ParticipantPortalTransformer::toObservationScheduleDTO)
+                    .toList());
+        }
+        return dto;
+    }
+
+    public static ObservationScheduleDTO toObservationScheduleDTO(Range<Instant> schedule) {
+        return new ObservationScheduleDTO()
+                .start(schedule.getMinimum())
+                .end(schedule.getMaximum());
+    }
+
+    public static DataHealthStateDTO toDataHealStateDto(DataHealth dataHealth) {
+        DataHealthStateDTO dataHealhState;
+        if (dataHealth == null) {
+            dataHealhState = null;
+        } else if (!dataHealth.valid()) {
+            dataHealhState = DataHealthStateDTO.INVALID;
+        } else {
+            switch (dataHealth.state()) {
+                case PARTIAL, INCOMPLETE -> dataHealhState = DataHealthStateDTO.INCOMPLETE;
+                case COMPLETE -> dataHealhState = DataHealthStateDTO.COMPLETED;
+                default -> {
+                    try {
+                        dataHealhState = DataHealthStateDTO.fromValue(dataHealth.state().getValue());
+                    } catch (IllegalArgumentException e) {
+                        LOG.error("Unexpected data health state {}", dataHealth.state(), e);
+                        dataHealhState = null;
+                    }
+                }
+            }
+        }
+        return dataHealhState;
+    }
+}

--- a/src/main/java/io/redlink/more/data/controller/transformer/StudyTransformer.java
+++ b/src/main/java/io/redlink/more/data/controller/transformer/StudyTransformer.java
@@ -8,6 +8,7 @@ import io.redlink.more.data.api.app.v1.model.ObservationDTO;
 import io.redlink.more.data.api.app.v1.model.ObservationScheduleDTO;
 import io.redlink.more.data.api.app.v1.model.SimpleParticipantDTO;
 import io.redlink.more.data.api.app.v1.model.StudyDTO;
+import io.redlink.more.data.model.CompletedData;
 import io.redlink.more.data.model.Contact;
 import io.redlink.more.data.model.Observation;
 import io.redlink.more.data.model.ParticipantObservationSeed;
@@ -26,7 +27,7 @@ public final class StudyTransformer {
     private StudyTransformer() {
     }
 
-    public static StudyDTO toDTO(Study study, List<ParticipantObservationSeed> seeds) {
+    public static StudyDTO toDTO(Study study, List<ParticipantObservationSeed> seeds, List<CompletedData> completedData) {
         return new StudyDTO()
                 .active(study.active())
                 .studyTitle(study.title())
@@ -38,7 +39,7 @@ public final class StudyTransformer {
                 .contact(toDTO(study.contact()))
                 .start(study.startDate())
                 .end(study.endDate())
-                .observations(toDTO(seeds, study.observations(), study.participant().start(), study.participant().end()))
+                .observations(toDTO(seeds, study.observations(), study.participant().start(), study.participant().end(), completedData))
                 .version(BaseTransformers.toVersionTag(study.modified()))
                 ;
     }
@@ -69,17 +70,17 @@ public final class StudyTransformer {
                 ;
     }
 
-    public static List<ObservationDTO> toDTO(List<ParticipantObservationSeed> participantObservationSeeds, List<Observation> observations, Instant start, Instant end) {
+    public static List<ObservationDTO> toDTO(List<ParticipantObservationSeed> participantObservationSeeds, List<Observation> observations, Instant start, Instant end, List<CompletedData> completedData) {
         return observations.stream().map(o -> {
             var seed = participantObservationSeeds.stream()
                     .filter(s -> s.observationId() == o.observationId())
                     .findFirst()
                     .orElse(null);
-            return StudyTransformer.toDTO(seed, o, start, end);
+            return StudyTransformer.toDTO(seed, o, start, end, completedData.stream().filter(d -> d.observationId().equals(String.valueOf(o.observationId()))).toList());
         }).toList();
     }
 
-    public static ObservationDTO toDTO(ParticipantObservationSeed participantObservationSeed, Observation observation, Instant start, Instant end) {
+    public static ObservationDTO toDTO(ParticipantObservationSeed participantObservationSeed, Observation observation, Instant start, Instant end, List<CompletedData> completedData) {
         ObservationDTO dto = new ObservationDTO()
                 .observationId(String.valueOf(observation.observationId()))
                 .observationType(observation.type())
@@ -99,6 +100,13 @@ public final class StudyTransformer {
                             end)
                     .stream()
                     .map(StudyTransformer::toObservationScheduleDTO)
+                    .filter(schedule -> completedData.stream().noneMatch(d -> {
+                        Instant scheduleStart = schedule.getStart() != null ? schedule.getStart() : start;
+                        Instant scheduleEnd = schedule.getEnd() != null ? schedule.getEnd() : end;
+
+                        return d.scheduleStart().compareTo(scheduleStart) == 0
+                                && d.scheduleEnd().compareTo(scheduleEnd) == 0;
+                    }))
                     .toList());
         }
         return dto;

--- a/src/main/java/io/redlink/more/data/exception/ForbiddenException.java
+++ b/src/main/java/io/redlink/more/data/exception/ForbiddenException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Oesterreichische Vereinigung zur
+ * Foerderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.FORBIDDEN)
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException() {
+        super();
+    }
+    public ForbiddenException(String cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/io/redlink/more/data/exception/NotAuthorizedException.java
+++ b/src/main/java/io/redlink/more/data/exception/NotAuthorizedException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Oesterreichische Vereinigung zur
+ * Foerderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.UNAUTHORIZED)
+public class NotAuthorizedException extends RuntimeException {
+    public NotAuthorizedException() {
+        super();
+    }
+
+    public NotAuthorizedException(String cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/io/redlink/more/data/model/ActiveObservation.java
+++ b/src/main/java/io/redlink/more/data/model/ActiveObservation.java
@@ -1,0 +1,12 @@
+package io.redlink.more.data.model;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+public record ActiveObservation(
+        String observationId,
+        Instant scheduleStart,
+        Instant scheduleEnd
+) implements Serializable {
+
+}

--- a/src/main/java/io/redlink/more/data/model/CallbackResult.java
+++ b/src/main/java/io/redlink/more/data/model/CallbackResult.java
@@ -1,0 +1,7 @@
+package io.redlink.more.data.model;
+
+public record CallbackResult(
+        RoutingInfo routingInfo,
+        Integer observationId
+) {
+}

--- a/src/main/java/io/redlink/more/data/model/CompletedData.java
+++ b/src/main/java/io/redlink/more/data/model/CompletedData.java
@@ -1,0 +1,14 @@
+package io.redlink.more.data.model;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+public record CompletedData(
+        String observationId,
+        Instant scheduleStart,
+        Instant scheduleEnd
+) implements Serializable {
+    public static CompletedData fromActiveObservation(ActiveObservation activeObservation) {
+        return new CompletedData(activeObservation.observationId(), activeObservation.scheduleStart(), activeObservation.scheduleEnd());
+    }
+}

--- a/src/main/java/io/redlink/more/data/model/DataHealth.java
+++ b/src/main/java/io/redlink/more/data/model/DataHealth.java
@@ -1,0 +1,16 @@
+package io.redlink.more.data.model;
+
+public record DataHealth(
+        boolean valid,
+        ObservationDataState state
+) {
+    public static DataHealth MISSING = new DataHealth(true, ObservationDataState.MISSING);
+
+    @Override
+    public String toString() {
+        return "DataHealth{" +
+                "valid=" + valid +
+                ", state=" + state +
+                '}';
+    }
+}

--- a/src/main/java/io/redlink/more/data/model/LoginToken.java
+++ b/src/main/java/io/redlink/more/data/model/LoginToken.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.model;
+
+import java.util.Objects;
+
+public class LoginToken {
+
+    private Long studyId;
+    private Integer participantId;
+    private String application;
+    private String code;
+    private String codeHash;
+
+    public LoginToken() {
+    }
+
+    public Long getStudyId() {
+        return studyId;
+    }
+
+    public LoginToken setStudyId(Long studyId) {
+        this.studyId = studyId;
+        return this;
+    }
+
+    public Integer getParticipantId() {
+        return participantId;
+    }
+
+    public LoginToken setParticipantId(Integer participantId) {
+        this.participantId = participantId;
+        return this;
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public LoginToken setApplication(String application) {
+        this.application = application;
+        return this;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public LoginToken setCode(String code) {
+        this.code = code;
+        return this;
+    }
+
+    public String getCodeHash() {
+        return codeHash;
+    }
+
+    public LoginToken setCodeHash(String codeHash) {
+        this.codeHash = codeHash;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LoginToken that = (LoginToken) o;
+        return Objects.equals(studyId, that.studyId) && Objects.equals(participantId, that.participantId) && Objects.equals(application, that.application);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(studyId, participantId, application);
+    }
+
+    @Override
+    public String toString() {
+        return "LoginToken{" +
+                "studyId=" + studyId +
+                ", participantId=" + participantId +
+                ", application='" + application + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/io/redlink/more/data/model/ObservationDataHealth.java
+++ b/src/main/java/io/redlink/more/data/model/ObservationDataHealth.java
@@ -1,0 +1,12 @@
+package io.redlink.more.data.model;
+
+import java.time.Instant;
+
+public record ObservationDataHealth (
+    Long studyId,
+    Integer observationId,
+    Integer participantId,
+    Instant start,
+    Instant end,
+    DataHealth health
+){ }

--- a/src/main/java/io/redlink/more/data/model/ObservationDataState.java
+++ b/src/main/java/io/redlink/more/data/model/ObservationDataState.java
@@ -1,0 +1,40 @@
+package io.redlink.more.data.model;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum ObservationDataState {
+    MISSING("missing"),
+    INCOMPLETE("incomplete"),
+    PARTIAL("partial"),
+    COMPLETE("complete");
+    private final String value;
+
+    ObservationDataState(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "ObservationDataState{" +
+                "name='" + name() + "', " +
+                "value='" + value + '\'' +
+                '}';
+    }
+
+    private static final Map<String, ObservationDataState> LOOKUP;
+
+    static {
+        LOOKUP = Arrays.stream(ObservationDataState.values()).collect(Collectors.toMap(ObservationDataState::getValue, Function.identity()));
+    }
+
+    public static ObservationDataState fromValue(String value) {
+        return LOOKUP.get(value);
+    }
+}

--- a/src/main/java/io/redlink/more/data/model/ParticipantApplication.java
+++ b/src/main/java/io/redlink/more/data/model/ParticipantApplication.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class ParticipantApplication {
+
+    private Long studyId;
+    private Integer participantId;
+    private String application;
+    private UUID uuid;
+
+    public ParticipantApplication() {
+    }
+
+    public Long getStudyId() {
+        return studyId;
+    }
+
+    public ParticipantApplication setStudyId(Long studyId) {
+        this.studyId = studyId;
+        return this;
+    }
+
+    public Integer getParticipantId() {
+        return participantId;
+    }
+
+    public ParticipantApplication setParticipantId(Integer participantId) {
+        this.participantId = participantId;
+        return this;
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public ParticipantApplication setApplication(String application) {
+        this.application = application;
+        return this;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public ParticipantApplication setUuid(UUID uuid) {
+        this.uuid = uuid;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ParticipantApplication that = (ParticipantApplication) o;
+        return Objects.equals(studyId, that.studyId) && Objects.equals(participantId, that.participantId) && Objects.equals(application, that.application);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(studyId, participantId, application);
+    }
+
+    @Override
+    public String toString() {
+        return "ParticipantApplication{" +
+                "studyId=" + studyId +
+                ", participantId=" + participantId +
+                ", application='" + application + '\'' +
+                ", uuid=" + uuid +
+                '}';
+    }
+}

--- a/src/main/java/io/redlink/more/data/model/RoutingInfo.java
+++ b/src/main/java/io/redlink/more/data/model/RoutingInfo.java
@@ -31,10 +31,6 @@ public record RoutingInfo(
         this(studyId, participantId, studyGroupId.orElse(Integer.MIN_VALUE), observationGroupIds, studyActive, participantActive);
     }
 
-/*    public RoutingInfo(ApiRoutingInfo routingInfo, Integer participantId, boolean participantActive) {
-        this(routingInfo.studyId(), participantId, routingInfo.studyGroupId(), routingInfo.studyActive(), participantActive);
-    }*/
-
     public OptionalInt studyGroupId() {
         if (this.rawStudyGroupId < 0) {
             return OptionalInt.empty();
@@ -45,5 +41,9 @@ public record RoutingInfo(
 
     public boolean acceptData() {
         return studyActive && participantActive;
+    }
+
+    public String participantRef() {
+        return studyId + ":" + participantId;
     }
 }

--- a/src/main/java/io/redlink/more/data/model/RoutingInfoWithObservation.java
+++ b/src/main/java/io/redlink/more/data/model/RoutingInfoWithObservation.java
@@ -1,0 +1,7 @@
+package io.redlink.more.data.model;
+
+public record RoutingInfoWithObservation(
+        RoutingInfo routingInfo,
+        Integer observationId
+) {
+}

--- a/src/main/java/io/redlink/more/data/model/StudyParticipantUserDetails.java
+++ b/src/main/java/io/redlink/more/data/model/StudyParticipantUserDetails.java
@@ -1,0 +1,86 @@
+package io.redlink.more.data.model;
+
+import io.redlink.more.data.exception.NotAuthorizedException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+
+public class StudyParticipantUserDetails implements UserDetails {
+
+    private final StudyParticipantReference reference;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    // You can add more fields as needed (email, language, etc.)
+
+    public StudyParticipantUserDetails(long studyId, int participantId,
+                                       Collection<? extends GrantedAuthority> authorities) {
+
+        this.reference = new StudyParticipantReference(studyId, participantId);
+        this.authorities = authorities != null ? Collections.unmodifiableCollection(authorities) : Collections.emptyList();
+    }
+
+    // ==================== UserDetails methods ====================
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return "unused";
+    }
+
+    @Override
+    public String getUsername() {
+        return String.format("study_%s-participant_%s", reference.studyId(), reference.participantId());
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    // ==================== Custom getters ====================
+
+    public StudyParticipantReference getStudyParticipantReference() {
+        return reference;
+    }
+
+    // Optional: Helper method to get current user details easily
+    public static StudyParticipantUserDetails getCurrent() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal instanceof StudyParticipantUserDetails details) {
+            return details;
+        }
+        throw new NotAuthorizedException("This user is not authorized!");
+    }
+
+    public record StudyParticipantReference(
+            long studyId,
+            int participantId
+    ) implements Serializable {
+    }
+
+    ;
+
+}

--- a/src/main/java/io/redlink/more/data/repository/DataHealthRepository.java
+++ b/src/main/java/io/redlink/more/data/repository/DataHealthRepository.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.repository;
+
+import io.redlink.more.data.model.DataHealth;
+import io.redlink.more.data.model.ObservationDataHealth;
+import io.redlink.more.data.model.ObservationDataState;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.sql.Types;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+@Component
+public class DataHealthRepository {
+
+    private static final String GET_BY_PK = """
+            SELECT * FROM occurred_observation oo
+                     WHERE oo.study_id = :study_id AND oo.participant_id = :participant_id AND oo.observation_id = :observation_id AND oo.start = :start
+            """;
+    private static final String LIST_OCCURRED_OBSERVATION = """
+            SELECT * FROM occurred_observation oo
+                    WHERE oo.study_id = :study_id
+                        AND (:participant_id::INT IS NULL OR oo.participant_id = :participant_id)
+                        AND (:observation_id::INT IS NULL OR oo.observation_id = :observation_id)
+                        AND (:data_valid::BOOLEAN IS NULL OR oo.data_valid = :data_valid)
+                        AND (:data_states::observation_data_state[] IS NULL OR oo.data_state = ANY(:data_states::observation_data_state[]))
+                        AND (:start_time::TIMESTAMPTZ IS NULL OR oo.start >= :start_time)
+                        AND (:end_time::TIMESTAMPTZ IS NULL OR oo."end" <= :end_time)
+            """;
+
+    private static final String FIND_LAST_START_TIME = """
+            SELECT start FROM occurred_observation oo
+                    WHERE oo.study_id = :study_id
+                        AND (:participant_id::INT IS NULL OR oo.participant_id = :participant_id)
+                        AND (:observation_id::INT IS NULL OR oo.observation_id = :observation_id)
+                        AND (:data_valid::BOOLEAN IS NULL OR oo.data_valid = :data_valid)
+                        AND (:data_states::observation_data_state[] IS NULL OR oo.data_state = ANY(:data_states::observation_data_state[]))
+                    ORDER BY oo.start DESC
+                    LIMIT 1
+            """;
+
+    private static String DELETE_BY_STUDY_ID = """
+            DELETE FROM occurred_observation oo
+            WHERE oo.study_id = :study_id
+    """;
+
+    private static final String DELETE_ALL = "DELETE FROM occurred_observation";
+    private final JdbcTemplate template;
+    private final NamedParameterJdbcTemplate namedTemplate;
+
+    public DataHealthRepository(JdbcTemplate template) {
+        this.template = template;
+        this.namedTemplate = new NamedParameterJdbcTemplate(template);
+    }
+
+
+    public Optional<ObservationDataHealth> getByIds(long studyId, int participantId, int observationId, Instant start) {
+        try {
+            return Optional.ofNullable(namedTemplate.queryForObject(
+                    GET_BY_PK,
+                    new MapSqlParameterSource("study_id", studyId)
+                            .addValue("participant_id", participantId)
+                            .addValue("observation_id", observationId)
+                            .addValue("start", OffsetDateTime.ofInstant(start, ZoneOffset.UTC), Types.TIMESTAMP_WITH_TIMEZONE)
+                    ,
+                    getObservationDataHealthRowMapper()));
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    public Stream<ObservationDataHealth> listObservationDataHealth(
+            Long studyId, Integer participantId, Integer observationId,
+            Boolean dataValid,
+            Set<ObservationDataState> dataStates,
+            Instant startTime,
+            Instant endTime
+    ) {
+        return namedTemplate.queryForStream(LIST_OCCURRED_OBSERVATION,
+                new MapSqlParameterSource("study_id", studyId)
+                        .addValue("participant_id", participantId)
+                        .addValue("observation_id", observationId)
+                        .addValue("data_valid", dataValid)
+                        .addValue("data_states", dataStates == null ? null : dataStates.stream().map(ObservationDataState::getValue).toArray(String[]::new))
+                        .addValue("start_time", startTime == null ? null : startTime.atOffset(ZoneOffset.UTC))
+                        .addValue("end_time", endTime == null ? null : endTime.atOffset(ZoneOffset.UTC)),
+                getObservationDataHealthRowMapper());
+    }
+
+    public Instant getLatestStartTime(
+            Long studyId, Integer participantId, Integer observationId,
+            Boolean dataValid, Set<ObservationDataState> dataStates
+    ) {
+        try {
+            return namedTemplate.queryForObject(FIND_LAST_START_TIME,
+                    new MapSqlParameterSource("study_id", studyId)
+                            .addValue("participant_id", participantId)
+                            .addValue("observation_id", observationId)
+                            .addValue("data_valid", dataValid)
+                            .addValue("data_states", dataStates == null ? null : dataStates.stream().map(ObservationDataState::getValue).toArray(String[]::new)),
+                    getInstantRowMapper("start", true));
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+
+    private static MapSqlParameterSource toParams(Long studyId) {
+        return new MapSqlParameterSource()
+                .addValue("study_id", studyId)
+                ;
+    }
+
+    private static MapSqlParameterSource toParams(Long studyId, Integer participantId, Integer observationId) {
+        return toParams(studyId)
+                .addValue("participant_id", participantId)
+                .addValue("observation_id", observationId);
+    }
+
+    private static RowMapper<ObservationDataHealth> getObservationDataHealthRowMapper() {
+        return (rs, rowNum) -> new ObservationDataHealth(
+                rs.getLong("study_id"),
+                rs.getInt("observation_id"),
+                rs.getInt("participant_id"),
+                DbUtils.toInstant(rs.getTimestamp("start", DbUtils.tzUTC)),
+                DbUtils.toInstant(rs.getTimestamp("end", DbUtils.tzUTC)),
+                new DataHealth(
+                    rs.getBoolean("data_valid"),
+                    ObservationDataState.fromValue(rs.getString("data_state"))));
+    }
+    private static RowMapper<Instant> getInstantRowMapper(String field, boolean withTimezone) {
+        return (rs, rowNum) -> withTimezone ? DbUtils.toInstant(rs.getTimestamp(field, DbUtils.tzUTC)) :
+                DbUtils.toInstant(rs.getTimestamp(field));
+    }
+
+}

--- a/src/main/java/io/redlink/more/data/repository/DbUtils.java
+++ b/src/main/java/io/redlink/more/data/repository/DbUtils.java
@@ -14,6 +14,7 @@ import java.sql.*;
 import java.sql.Date;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -21,6 +22,7 @@ import java.util.stream.Stream;
 public final class DbUtils {
 
     private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+    public static final Calendar tzUTC = Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.UTC));
 
     private DbUtils() {}
 

--- a/src/main/java/io/redlink/more/data/repository/LoginTokenRepository.java
+++ b/src/main/java/io/redlink/more/data/repository/LoginTokenRepository.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.repository;
+
+import io.redlink.more.data.model.LoginToken;
+import io.redlink.more.data.model.ParticipantApplication;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class LoginTokenRepository {
+    private static final String SELECT_BY_CODE_HASH =
+            "SELECT * FROM login_tokens WHERE code_hash = ? AND study_id = ? AND application = ? AND participant_id = ?";
+    private static final String DELETE_SALT =
+            "DELETE FROM salt_tokens WHERE study_id = ? AND participant_id = ?";
+    private static final String DELETE_BY_PARTICIPANT =
+            "DELETE FROM login_tokens WHERE study_id = ? AND participant_id = ?";
+
+    private final JdbcTemplate template;
+
+    public LoginTokenRepository(JdbcTemplate template) {
+        this.template = template;
+    }
+
+    public Optional<LoginToken> findByCodeHash(String codeHash, ParticipantApplication application) {
+        return template.query(SELECT_BY_CODE_HASH, getRowMapper(), codeHash, application.getStudyId(), application.getApplication(), application.getParticipantId())
+                .stream().findFirst();
+    }
+
+    public void deleteLoginTokens(Long studyId, Integer participantId) {
+        if (participantId == null || studyId == null) {
+            return;
+        }
+        template.update(DELETE_BY_PARTICIPANT, studyId, participantId);
+        template.update(DELETE_SALT, studyId, participantId);
+    }
+
+    private RowMapper<LoginToken> getRowMapper() {
+        return (rs, rowNum) -> new LoginToken()
+                .setStudyId(rs.getLong("study_id"))
+                .setParticipantId(rs.getInt("participant_id"))
+                .setApplication(rs.getString("application"))
+                .setCode(rs.getString("code"))
+                .setCodeHash(rs.getString("code_hash"));
+    }
+}

--- a/src/main/java/io/redlink/more/data/repository/ParticipantApplicationRepository.java
+++ b/src/main/java/io/redlink/more/data/repository/ParticipantApplicationRepository.java
@@ -1,0 +1,46 @@
+package io.redlink.more.data.repository;
+
+import io.redlink.more.data.model.ParticipantApplication;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class ParticipantApplicationRepository {
+    private static final String SELECT_BY_UUID =
+            "SELECT * FROM participant_applications WHERE study_id = ? AND uuid = ?";
+
+    private static final String DELETE_BY_PARTICIPANT =
+            "DELETE FROM participant_applications WHERE study_id = ? AND participant_id = ?";
+
+    private final JdbcTemplate template;
+
+    public ParticipantApplicationRepository(JdbcTemplate template) {
+        this.template = template;
+    }
+
+    public Optional<ParticipantApplication> findByUserDataReference(Long studyId, String userDataReference) {
+        try {
+            UUID uuid = UUID.fromString(userDataReference);
+            return template.query(SELECT_BY_UUID, getRowMapper(), studyId, uuid)
+                    .stream().findFirst();
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    public void deleteAllByParticipant(Long studyId, Integer participantId) {
+        template.update(DELETE_BY_PARTICIPANT, studyId, participantId);
+    }
+
+    private RowMapper<ParticipantApplication> getRowMapper() {
+        return (rs, rowNum) -> new ParticipantApplication()
+                .setStudyId(rs.getLong("study_id"))
+                .setParticipantId(rs.getInt("participant_id"))
+                .setApplication(rs.getString("application"))
+                .setUuid(rs.getObject("uuid", UUID.class));
+    }
+}

--- a/src/main/java/io/redlink/more/data/repository/StudyRepository.java
+++ b/src/main/java/io/redlink/more/data/repository/StudyRepository.java
@@ -10,6 +10,8 @@ import io.redlink.more.data.util.MapperUtils;
 import io.redlink.more.data.util.RandomSchedulerUtils;
 import io.redlink.more.data.util.SchedulerUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -42,6 +44,7 @@ import static io.redlink.more.data.util.RandomSchedulerUtils.OBSERVATION_SCHEDUL
 
 @Service
 public class StudyRepository {
+    private static final Logger LOG = LoggerFactory.getLogger(StudyRepository.class);
 
     private static final String SQL_FIND_STUDY_BY_ID =
             "SELECT *, status IN ('active', 'preview') as study_active FROM studies WHERE study_id = ?";
@@ -111,6 +114,19 @@ public class StudyRepository {
             """;
     private static final String SQL_ROUTING_INFO_BY_REG_TOKEN_WITH_LOCK =
             SQL_ROUTING_INFO_BY_REG_TOKEN + " FOR UPDATE OF rt";
+    private static final String SQL_PARTICIPANT_ID_AND_OBSERVATION_ID_BY_OBSERVATION_TOKEN = """
+            SELECT pop.participant_id, pop.observation_id
+            FROM participant_observation_properties pop
+            WHERE pop.study_id = ?
+              AND pop.properties ->> 'token' = ?
+            LIMIT 1
+            """;
+    private static final String SQL_STUDY_ID_PARTICIPANT_ID_AND_OBSERVATION_ID_BY_OBSERVATION_TOKEN = """
+            SELECT pop.study_id, pop.participant_id, pop.observation_id
+            FROM participant_observation_properties pop
+            WHERE pop.properties ->> 'token' = ?
+            LIMIT 1
+            """;
     private static final String GET_ROUTING_INFO = """
             SELECT pt.study_id as study_id, pt.participant_id as participant_id, study_group_id,
                 s.status IN ('active', 'preview') as study_active,
@@ -149,6 +165,16 @@ public class StudyRepository {
                     UPDATE participation_consents
                     SET consent_withdrawn = now()
                     WHERE study_id = :study_id AND participant_id = :participant_id""";
+
+    private static final String SQL_GET_CONSENT = """
+            SELECT accepted, origin, content_md5, consent_timestamp, consent_withdrawn
+            FROM participation_consents
+            WHERE study_id = :study_id AND participant_id = :participant_id""";
+
+    private static final String SQL_GET_OBSERVATION_CONSENTS = """
+            SELECT observation_id
+            FROM observation_consents
+            WHERE study_id = :study_id AND participant_id = :participant_id""";
 
     private static final String SQL_INSERT_OBSERVATION_CONSENT =
             """
@@ -328,6 +354,53 @@ public class StudyRepository {
     public Optional<RoutingInfo> getRoutingInfo(Long studyId, Integer participantId) {
         try (var stream = jdbcTemplate.queryForStream(GET_ROUTING_INFO, getRoutingInfoMapper(), studyId, participantId)) {
             return stream.findFirst();
+        }
+    }
+
+    public Optional<RoutingInfoWithObservation> getRoutingInfoAndObservationIdByToken(long studyId, String token) {
+        try {
+            Pair<Integer, Integer> participantAndObservationId = jdbcTemplate.queryForObject(
+                    SQL_PARTICIPANT_ID_AND_OBSERVATION_ID_BY_OBSERVATION_TOKEN,
+                    (rs, rowNum) -> Pair.of(
+                            rs.getInt("participant_id"),
+                            rs.getInt("observation_id")
+                    ),
+                    studyId, token
+            );
+
+            if (participantAndObservationId == null) {
+                LOG.warn("Participant and observation id not found for token {} in study {}", token, studyId);
+                return Optional.empty();
+            }
+
+            return getRoutingInfo(studyId, participantAndObservationId.getLeft())
+                    .map(routingInfo -> new RoutingInfoWithObservation(routingInfo, participantAndObservationId.getRight()));
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<RoutingInfoWithObservation> getRoutingInfoAndObservationIdByToken(String token) {
+        try {
+            var studyParticipantAndObservationId = jdbcTemplate.queryForObject(
+                    SQL_STUDY_ID_PARTICIPANT_ID_AND_OBSERVATION_ID_BY_OBSERVATION_TOKEN,
+                    (rs, rowNum) -> new Object() {
+                        final long studyId = rs.getLong("study_id");
+                        final int participantId = rs.getInt("participant_id");
+                        final int observationId = rs.getInt("observation_id");
+                    },
+                    token
+            );
+
+            if (studyParticipantAndObservationId == null) {
+                LOG.warn("Study, participant and observation id not found for token {}", token);
+                return Optional.empty();
+            }
+
+            return getRoutingInfo(studyParticipantAndObservationId.studyId, studyParticipantAndObservationId.participantId)
+                    .map(routingInfo -> new RoutingInfoWithObservation(routingInfo, studyParticipantAndObservationId.observationId));
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
         }
     }
 
@@ -728,10 +801,15 @@ public class StudyRepository {
 
         if (apiId != null) {
             jdbcTemplate.update(SQL_CLEAR_TOKEN, registrationToken);
-            updateParticipantStatus(routingInfo.studyId(), routingInfo.studyGroupId().orElse(0), routingInfo.observationGroupIds(), routingInfo.participantId(), "new", "active");
+            updateParticipantStatus(routingInfo, "new", "invited");
+            updateParticipantStatus(routingInfo, "invited", "active");
             return Optional.of(apiId);
         }
         throw new IllegalStateException("Creating API-Credentials failed!");
+    }
+
+    public void updateParticipantStatus(RoutingInfo routingInfo, String oldStatus, String newStatus) {
+        updateParticipantStatus(routingInfo.studyId(), routingInfo.studyGroupId().orElse(0), routingInfo.observationGroupIds(), routingInfo.participantId(), oldStatus, newStatus);
     }
 
     private void updateParticipantStatus(long studyId, int studyGroupId, Collection<Integer> observationGroupIds, int participantId, String oldStatus, String newStatus) {
@@ -751,7 +829,7 @@ public class StudyRepository {
         namedTemplate.update(SQL_SET_PARTICIPANT_STATUS, parameterSource);
     }
 
-    private void storeConsent(long studyId, int participantId, ParticipantConsent consent) {
+    public void storeConsent(long studyId, int participantId, ParticipantConsent consent) {
         // Store Study-Consent
         namedTemplate.update(SQL_INSERT_STUDY_CONSENT, toParameterSource(studyId, participantId, consent));
         // Store Consent for individual Observations
@@ -759,6 +837,40 @@ public class StudyRepository {
                 consent.observationConsents().stream()
                         .map(c -> toParameterSource(studyId, participantId, c))
                         .toArray(SqlParameterSource[]::new));
+    }
+
+    public Optional<ParticipantConsent> getConsent(long studyId, Integer participantId) {
+        try {
+            return namedTemplate.query(SQL_GET_CONSENT,
+                    new MapSqlParameterSource()
+                            .addValue("study_id", studyId)
+                            .addValue("participant_id", participantId),
+                    rs -> {
+                        if (rs.next()) {
+                            return Optional.of(new ParticipantConsent(
+                                    rs.getBoolean("accepted"),
+                                    rs.getString("origin"),
+                                    rs.getString("content_md5"),
+                                    toInstant(rs.getTimestamp("consent_timestamp")),
+                                    getObservationConsents(studyId, participantId)
+                            ));
+                        }
+                        return Optional.empty();
+                    });
+        } catch (DataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    private List<ParticipantConsent.ObservationConsent> getObservationConsents(long studyId, int participantId) {
+        return namedTemplate.query(SQL_GET_OBSERVATION_CONSENTS,
+                new MapSqlParameterSource()
+                        .addValue("study_id", studyId)
+                        .addValue("participant_id", participantId),
+                (rs, rowNum) -> new ParticipantConsent.ObservationConsent(
+                        rs.getInt("observation_id"),
+                        null
+                ));
     }
 
     private void withdrawConsent(long studyId, int participantId) {

--- a/src/main/java/io/redlink/more/data/service/ApplicationAccessService.java
+++ b/src/main/java/io/redlink/more/data/service/ApplicationAccessService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.service;
+
+import io.redlink.more.data.event.ParticipantUpdateEvent;
+import io.redlink.more.data.model.ParticipantApplication;
+import io.redlink.more.data.model.ParticipantConsent;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.repository.ParticipantApplicationRepository;
+import io.redlink.more.data.repository.StudyRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class ApplicationAccessService implements ApplicationListener<ParticipantUpdateEvent> {
+    private static final Logger LOG = LoggerFactory.getLogger(ApplicationAccessService.class);
+    private final LoginTokenService loginTokenService;
+    private final ParticipantApplicationRepository participantApplicationRepository;
+    private final StudyRepository studyRepository;
+
+    public ApplicationAccessService(LoginTokenService loginTokenService, ParticipantApplicationRepository participantApplicationRepository, StudyRepository studyRepository) {
+        this.loginTokenService = loginTokenService;
+        this.participantApplicationRepository = participantApplicationRepository;
+        this.studyRepository = studyRepository;
+    }
+
+    public Optional<RoutingInfo> validateLogin(Long studyId, String userDataReference, String loginToken) {
+        Optional<ParticipantApplication> application = participantApplicationRepository.findByUserDataReference(studyId, userDataReference);
+        if (application.isEmpty()) {
+            LOG.warn("No application found for study {} and user data reference {}", studyId, userDataReference);
+            return Optional.empty();
+        }
+        return loginTokenService.validateToken(loginToken, application.get());
+    }
+
+    public boolean hasConsent(RoutingInfo routingInfo) {
+        Optional<ParticipantConsent> existingConsent = studyRepository.getConsent(routingInfo.studyId(), routingInfo.participantId());
+        return existingConsent.map(ParticipantConsent::accepted).orElse(false);
+    }
+
+    public void validateAndStoreConsent(RoutingInfo routingInfo, ParticipantConsent consent) {
+        if (consent.accepted()) {
+            studyRepository.storeConsent(routingInfo.studyId(), routingInfo.participantId(), consent);
+            studyRepository.updateParticipantStatus(routingInfo, "invited", "active");
+        } else {
+            LOG.warn("Consent {} is not accepted by user {}", consent, routingInfo);
+            throw new IllegalStateException("Consent was not accepted!");
+        }
+    }
+
+    @Override
+    public void onApplicationEvent(ParticipantUpdateEvent event) {
+        switch (event.getAction()) {
+            case DELETE ->
+                    participantApplicationRepository.deleteAllByParticipant(event.getStudyId(), event.getParticipantId());
+        }
+    }
+}

--- a/src/main/java/io/redlink/more/data/service/DataHealthService.java
+++ b/src/main/java/io/redlink/more/data/service/DataHealthService.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.service;
+
+import io.redlink.more.data.model.DataHealth;
+import io.redlink.more.data.model.ObservationDataHealth;
+import io.redlink.more.data.model.ObservationDataState;
+import io.redlink.more.data.repository.DataHealthRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+@Service
+public class DataHealthService {
+
+    private final DataHealthRepository repository;
+
+    private static final EnumSet<ObservationDataState> COMPLETED_DATA_STATES = EnumSet.of(ObservationDataState.COMPLETE);
+    private static final EnumSet<ObservationDataState> ACTIVE_DATA_STATES = EnumSet.complementOf(COMPLETED_DATA_STATES);
+
+    public DataHealthService(DataHealthRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * The latest start time of any {@link OccurredObservation} for the parst studyId
+     * @param studyId the study id
+     * @param participantId the participantId
+     * @return the latest start time or <code>null</code> if no {@link OccurredObservation} is present for the study
+     */
+    public Instant getLatestStartTime(
+            long studyId,
+            int participantId,
+            Instant startTime,
+            Instant endTime) {
+        return repository.getLatestStartTime(studyId, participantId, null, null, null);
+    }
+
+    /**
+     * Stream over all occurred observations for a study. <p>
+     * <b>NOTE:</b> DO NOT forget to close the returned stream!!
+     * {@link ObservationDataState#COMPLETE})
+     * @param studyId the study id
+     * @param startTime if present it filters for <code>oo.start &gt;= startTime</code>
+     * @param endTime if present it filters for <code>oo.end &lt;= endTime</code>
+     * @param includeInvalid if occurred observations marked as having invalid data are included
+     * @param includeCompleted if FALSE DataHealh information is only provided for observation with incomplete/missing data
+     * @return a stream over all ongoing or occurred observations where data are still missing
+     */
+    public Stream<ObservationDataHealth> streamDataHealthForStudy(
+            long studyId,
+            Instant startTime,
+            Instant endTime,
+            boolean includeInvalid,
+            boolean includeCompleted
+    ) {
+        return repository.listObservationDataHealth(
+                studyId, null, null,
+                includeInvalid ? null : true,
+                includeCompleted ? null : ACTIVE_DATA_STATES,
+                startTime,
+                endTime);
+    }
+
+    /**
+     * Stream over all data health data for an observation of a study. <p>
+     * <b>NOTE:</b> DO NOT forget to close the returned stream!!
+     * {@link ObservationDataState#COMPLETE})
+     * @param studyId the study id
+     * @param observationId the observation id
+     * @param startTime if present it filters for <code>oo.start &gt;= startTime</code>
+     * @param endTime if present it filters for <code>oo.end &lt;= endTime</code>
+     * @param includeInvalid if occurred observations marked as having invalid data are included
+     * @param includeCompleted if FALSE DataHealh information is only provided for observation with incomplete/missing data
+     * @return a stream over all ongoing or occurred observations where data are still missing
+     */
+    public Stream<ObservationDataHealth> streamObservationDataHealthForObservation(
+            long studyId,
+            int observationId,
+            Instant startTime,
+            Instant endTime,
+            boolean includeInvalid,
+            boolean includeCompleted
+    ) {
+        return repository.listObservationDataHealth(
+                studyId, null, observationId,
+                includeInvalid ? null : true,
+                includeCompleted ? null : ACTIVE_DATA_STATES,
+                startTime,
+                endTime);
+    }
+
+    /**
+     * Stream over all occurred observations for a participant of a study.<p>
+     * <b>NOTE:</b> DO NOT forget to close the returned stream!!
+     * @param studyId the study id
+     * @param participantId the participant id
+     * @param startTime if present it filters for <code>oo.start &gt;= startTime</code>
+     * @param endTime if present it filters for <code>oo.end &lt;= endTime</code>
+     * @param includeInvalid if occurred observations marked as having invalid data are included
+     * @param includeCompleted if FALSE DataHealh information is only provided for observation with incomplete/missing data
+     * @return a stream over all ongoing or occurred observations where data are still missing
+     */
+    public Stream<ObservationDataHealth> streamObservationDataHealthForParticipant(
+            long studyId,
+            int participantId,
+            Instant startTime,
+            Instant endTime,
+            boolean includeInvalid,
+            boolean includeCompleted
+    ) {
+        return repository.listObservationDataHealth(
+                studyId, participantId, null,
+                includeInvalid ? null : true,
+                includeCompleted ? null : ACTIVE_DATA_STATES,
+                startTime,
+                endTime);
+    }
+
+    /**
+     * Gets all occurred observations for a participant of a study, where data is still missing (not in
+     * {@link ObservationDataState#COMPLETE})
+     * @param studyId the study id
+     * @param participantId the participant id
+     * @param observationId the observation id
+     * @param includeInvalid if occurred observations marked as having invalid data are included
+     * @param observationDataStates the states to include or <code>null</code> to include all
+     * @param startTime if present it filters for <code>oo.start &gt;= startTime</code>
+     * @param endTime if present it filters for <code>oo.end &lt;= endTime</code>
+     * @return a stream over all ongoing or occurred observations where data are still missing
+     */
+    public List<ObservationDataHealth> listDataHealth(
+            long studyId,
+            int participantId,
+            int observationId,
+            boolean includeInvalid,
+            Set<ObservationDataState> observationDataStates,
+            Instant startTime,
+            Instant endTime
+    ) {
+        try (Stream<ObservationDataHealth> stream = repository.listObservationDataHealth(
+                studyId, participantId, observationId,
+                includeInvalid ? null : true,
+                observationDataStates == null ? EnumSet.allOf(ObservationDataState.class) : observationDataStates,
+                startTime,
+                endTime)) {
+            return stream.toList();
+        }
+    }
+
+    /**
+     * Gets all occurred observations for a participant of a study, where data is still missing (not in
+     * {@link ObservationDataState#COMPLETE})
+     * @param studyId the study id
+     * @param participantId the participant id or <code>null</code> as wildcard
+     * @param observationId the observation id  or <code>null</code> as wildcard
+     * @param startTime if present it filters for <code>oo.start &gt;= startTime</code>
+     * @return the data health of the matching OccurredObservation or {@link DataHealth#MISSING} if not found
+     */
+    public DataHealth checkDataHealth(
+            long studyId,
+            int participantId,
+            int observationId,
+            Instant startTime) {
+        return repository.getByIds(studyId, participantId, observationId, startTime)
+                .map(ObservationDataHealth::health)
+                .orElse(DataHealth.MISSING);
+    }
+}

--- a/src/main/java/io/redlink/more/data/service/ExternalService.java
+++ b/src/main/java/io/redlink/more/data/service/ExternalService.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 public class ExternalService {
@@ -71,7 +70,7 @@ public class ExternalService {
                 throw new AccessDeniedException("Invalid token");
             }
             return apiRoutingInfo.get();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             throw new AccessDeniedException("Invalid token");
         }
     }
@@ -118,7 +117,7 @@ public class ExternalService {
             }
         } catch (BadRequestException e) {
             throw e;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             throw BadRequestException.NotFound(studyId, observationId);
         }
     }

--- a/src/main/java/io/redlink/more/data/service/LoginTokenService.java
+++ b/src/main/java/io/redlink/more/data/service/LoginTokenService.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.service;
+
+import io.redlink.more.data.configuration.LoginTokenProperties;
+import io.redlink.more.data.event.ParticipantUpdateEvent;
+import io.redlink.more.data.model.ParticipantApplication;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.repository.LoginTokenRepository;
+import io.redlink.more.data.repository.StudyRepository;
+import org.apache.commons.codec.binary.Hex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
+
+@Service
+public class LoginTokenService implements ApplicationListener<ParticipantUpdateEvent> {
+
+    private static final Logger log = LoggerFactory.getLogger(LoginTokenService.class);
+
+    private final LoginTokenRepository loginTokenRepository;
+    private final LoginTokenProperties properties;
+    private final StudyRepository studyRepository;
+
+    public LoginTokenService(LoginTokenRepository loginTokenRepository, LoginTokenProperties properties, StudyRepository studyRepository) {
+        this.loginTokenRepository = loginTokenRepository;
+        this.properties = properties;
+        this.studyRepository = studyRepository;
+    }
+
+    public Optional<RoutingInfo> validateToken(String code, ParticipantApplication application) {
+        return loginTokenRepository
+                .findByCodeHash(hashToken(code), application)
+                .flatMap(token -> studyRepository.getRoutingInfo(token.getStudyId(), token.getParticipantId()));
+    }
+
+    @Override
+    public void onApplicationEvent(ParticipantUpdateEvent event) {
+        switch (event.getAction()) {
+            case DELETE -> loginTokenRepository.deleteLoginTokens(event.getStudyId(), event.getParticipantId());
+        }
+    }
+
+    private String hashToken(String input) {
+        if (input == null) {
+            return null;
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance(properties.getHashAlgorithm());
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return Hex.encodeHexString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            log.error("Hash algorithm {} not found", properties.getHashAlgorithm());
+            return input;
+        }
+    }
+}

--- a/src/main/java/io/redlink/more/data/service/ObservationExecutionService.java
+++ b/src/main/java/io/redlink/more/data/service/ObservationExecutionService.java
@@ -1,0 +1,152 @@
+package io.redlink.more.data.service;
+
+import io.redlink.more.data.exception.ForbiddenException;
+import io.redlink.more.data.exception.NotFoundException;
+import io.redlink.more.data.model.ActiveObservation;
+import io.redlink.more.data.model.CallbackResult;
+import io.redlink.more.data.model.CompletedData;
+import io.redlink.more.data.model.Observation;
+import io.redlink.more.data.model.ParticipantObservationSeed;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.model.Study;
+import io.redlink.more.data.service.observations.ObservationComponent;
+import io.redlink.more.data.store.observationCallback.ObservationCallbackStore;
+import io.redlink.more.data.util.SchedulerUtils;
+import org.apache.commons.lang3.Range;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class ObservationExecutionService {
+    private static final Logger LOG = LoggerFactory.getLogger(ObservationExecutionService.class);
+
+    private final StudyService studyService;
+    private final ObservationCallbackStore callbackStore;
+    private final Map<String, ObservationComponent> observationComponents;
+
+    public ObservationExecutionService(
+            StudyService studyService,
+            ObservationCallbackStore callbackStore,
+            List<ObservationComponent> observationComponents) {
+        this.studyService = studyService;
+        this.callbackStore = callbackStore;
+        this.observationComponents = observationComponents.stream()
+                .collect(Collectors.toMap(ObservationComponent::getObservationType, c -> c));
+    }
+
+    public Optional<URI> executeObservation(String observationId, Instant scheduleStart, Instant scheduleEnd, RoutingInfo routingInfo, String redirect) {
+        if (observationId.isBlank() || !StringUtils.isNumeric(observationId)) {
+            throw new NotFoundException("Observation not found!");
+        }
+        ActiveObservation activeObservation = new ActiveObservation(observationId, scheduleStart, scheduleEnd);
+        if (callbackStore.isCompleted(routingInfo, activeObservation)) {
+            LOG.debug("Observation {} already done, redirecting...", CompletedData.fromActiveObservation(activeObservation));
+            if (redirect != null) {
+                return Optional.of(UriComponentsBuilder.fromUriString(redirect)
+                        .replaceQueryParam("status", HttpStatus.CONFLICT.value())
+                        .build().toUri());
+            }
+            return Optional.empty();
+        }
+
+        if (redirect != null && !redirect.isBlank()) {
+            callbackStore.saveRedirect(routingInfo, activeObservation, redirect);
+        }
+
+        LOG.info("Starting observation {} for routinginfo {}", activeObservation, routingInfo);
+
+        Optional<Pair<Study, List<ParticipantObservationSeed>>> studyResult = studyService.getStudy(routingInfo);
+        if (studyResult.isEmpty()) {
+            throw new NotFoundException("Study not found for " + routingInfo);
+        }
+
+        Study study = studyResult.get().getLeft();
+        List<ParticipantObservationSeed> seeds = studyResult.get().getRight();
+
+        String state = study.studyState();
+        if (!"active".equalsIgnoreCase(state) && !"preview".equalsIgnoreCase(state)) {
+            throw new ForbiddenException("Study is not active or in preview");
+        }
+
+        int observationIdAsInt = Integer.parseInt(observationId);
+
+        Optional<Observation> studyObservation = study.observations().stream()
+                .filter(o -> o.observationId() == observationIdAsInt)
+                .findFirst();
+
+        if (studyObservation.isEmpty()) {
+            throw new NotFoundException("Observation " + observationId + " not found in study " + study.studyId());
+        }
+        Observation observation = studyObservation.get();
+
+        ObservationComponent component = observationComponents.get(observation.type());
+        if (component == null) {
+            throw new NotFoundException("Component for observation type " + observation.type() + " not found");
+        }
+
+        ParticipantObservationSeed seed = seeds.stream()
+                .filter(s -> String.valueOf(s.observationId()).equals(observationId))
+                .findFirst()
+                .orElse(null);
+
+        ZoneId zoneId = ZoneId.systemDefault();
+        Instant start = study.startDate() != null ? study.startDate().atStartOfDay(zoneId).toInstant() : scheduleStart.atZone(zoneId).toLocalDate().atStartOfDay(zoneId).toInstant();
+        Instant end = study.endDate() != null ? study.endDate().plusDays(1).atStartOfDay(zoneId).toInstant() : scheduleEnd.atZone(zoneId).toLocalDate().plusDays(1).atStartOfDay(zoneId).toInstant();
+
+        List<Range<Instant>> validRanges = SchedulerUtils.parseToObservationSchedules(seed, observation.observationSchedule(), start, end);
+        boolean isValidSchedule = validRanges.stream()
+                .anyMatch(r -> (r.getMinimum().equals(scheduleStart) && r.getMaximum().equals(scheduleEnd))
+                        || r.contains(scheduleStart) && r.contains(scheduleEnd));
+
+        if (!isValidSchedule) {
+            LOG.error("Provided schedule is not valid for observation {}: scheduleStart: {}; scheduleEnd: {}; validRanges: {}", observationId, scheduleStart, scheduleEnd, validRanges);
+            throw new ForbiddenException("Provided schedule is not valid for observation " + observationId);
+        }
+
+        var uri = URI.create(component.produceUrl(observation, routingInfo, scheduleStart, scheduleEnd)
+                .orElseThrow(() -> new NotFoundException("Could not produce URL for observation " + observationId)));
+        LOG.info("Opening url `{}` for routinginfo {} and observation schedule {}", uri, routingInfo, activeObservation);
+        return Optional.of(uri);
+    }
+
+    public Optional<URI> processCallback(Map<String, String> parameters) {
+        LOG.info("process callback for params: {}", parameters);
+        Optional<CallbackResult> cbResult = Optional.empty();
+        for (ObservationComponent component : observationComponents.values()) {
+            if (component.necessaryCallbackParameters(parameters)) {
+                var result = component.processCallback(parameters);
+                if (result.isPresent()) {
+                    LOG.info("mapped to {} with result: {}", component.getClass().getSimpleName(), result);
+                    cbResult = result;
+                    break;
+                }
+            } else {
+                LOG.info("Necessary parameters not provided for component {}", component.getClass().getSimpleName());
+            }
+        }
+
+        if (cbResult.isPresent()) {
+            return callbackStore.pullRedirect(cbResult.get().routingInfo(), cbResult.get().observationId());
+        }
+
+        LOG.warn("No callback result generated for callback result: {}, params: {}", cbResult, parameters);
+        return Optional.empty();
+    }
+
+    public List<CompletedData> getCompletedData(RoutingInfo routingInfo) {
+        return callbackStore.getCompletedData(routingInfo);
+    }
+}

--- a/src/main/java/io/redlink/more/data/service/RegistrationService.java
+++ b/src/main/java/io/redlink/more/data/service/RegistrationService.java
@@ -3,13 +3,11 @@
  */
 package io.redlink.more.data.service;
 
-import io.redlink.more.data.controller.transformer.StudyTransformer;
 import io.redlink.more.data.event.ParticipantUpdateAction;
 import io.redlink.more.data.event.ParticipantUpdateEvent;
 import io.redlink.more.data.exception.RegistrationNotPossibleException;
 import io.redlink.more.data.model.ApiCredentials;
 import io.redlink.more.data.model.ParticipantConsent;
-import io.redlink.more.data.model.ParticipantObservationSeed;
 import io.redlink.more.data.model.RoutingInfo;
 import io.redlink.more.data.model.Study;
 import io.redlink.more.data.repository.PushTokenRepository;
@@ -19,8 +17,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -45,29 +41,8 @@ public class RegistrationService {
         return studyRepository.findByRegistrationToken(registrationToken);
     }
 
-    public List<ParticipantObservationSeed> getParticipantObservationSeeds(Long studyId, Integer participantId) {
-        var properties = studyRepository.getAllParticpantObservationProperties(studyId, participantId);
-        if (properties == null || properties.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return properties
-                .stream()
-                .map(StudyTransformer::toParticipantObservationSeed)
-                .filter(seed -> seed.seed() != null)
-                .toList();
-    }
-
-    public Optional<Study> loadStudyByRoutingInfo(RoutingInfo routingInfo) {
-        return Optional.ofNullable(routingInfo)
-                .flatMap(studyRepository::findStudy);
-    }
-
-    public boolean validateConsent(ParticipantConsent consent) {
-        return consent.accepted();
-    }
-
     public Optional<ApiCredentials> register(String registrationToken, ParticipantConsent consent) {
-        if (!validateConsent(consent)) {
+        if (!consent.accepted()) {
             throw RegistrationNotPossibleException.noConsentGiven();
         }
         var s = studyRepository.findByRegistrationToken(registrationToken);

--- a/src/main/java/io/redlink/more/data/service/StudyService.java
+++ b/src/main/java/io/redlink/more/data/service/StudyService.java
@@ -1,0 +1,70 @@
+package io.redlink.more.data.service;
+
+import io.redlink.more.data.controller.transformer.StudyTransformer;
+import io.redlink.more.data.model.ParticipantObservationSeed;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.model.RoutingInfoWithObservation;
+import io.redlink.more.data.model.Study;
+import io.redlink.more.data.repository.StudyRepository;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class StudyService {
+    private final StudyRepository studyRepository;
+
+    public StudyService(StudyRepository studyRepository) {
+        this.studyRepository = studyRepository;
+    }
+
+    /**
+     * Provides the full {@link RoutingInfo} for the parsed study participant reference
+     *
+     * @param studyId       the study id of the participant
+     * @param participantId the id of the participant within the study
+     * @return the {@link RoutingInfo} if the referenced study participant existed
+     */
+    public Optional<RoutingInfo> getRoutingInfo(long studyId, int participantId) {
+        return studyRepository.getRoutingInfo(studyId, participantId);
+    }
+
+    public Optional<RoutingInfoWithObservation> getRoutingInfoByToken(long studyId, String token) {
+//        return studyRepository.getRoutingInfoAndObservationIdByToken(studyId, token); --> only if limesurveys are not cross study
+        return studyRepository.getRoutingInfoAndObservationIdByToken(token); // Use cross study functionality with mcuh higher runtime
+    }
+
+    public Optional<String> getStudyState(long studyId) {
+        return studyRepository.getStudyState(studyId);
+    }
+
+    public Optional<Pair<Study, List<ParticipantObservationSeed>>> getStudy(RoutingInfo routingInfo) {
+        if (routingInfo == null) {
+            return Optional.empty();
+        }
+        Optional<Study> study = studyRepository.findStudy(routingInfo);
+        return study
+                .map(value -> Pair.of(
+                        value,
+                        value.active()
+                                ? getParticipantObservationSeeds(routingInfo.studyId(), routingInfo.participantId())
+                                : Collections.emptyList()))
+                ;
+    }
+
+
+    public List<ParticipantObservationSeed> getParticipantObservationSeeds(Long studyId, Integer participantId) {
+        var properties = studyRepository.getAllParticpantObservationProperties(studyId, participantId);
+        if (properties == null || properties.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return properties
+                .stream()
+                .map(StudyTransformer::toParticipantObservationSeed)
+                .filter(seed -> seed.seed() != null)
+                .toList();
+    }
+}

--- a/src/main/java/io/redlink/more/data/service/garmin/GarminService.java
+++ b/src/main/java/io/redlink/more/data/service/garmin/GarminService.java
@@ -208,7 +208,7 @@ public class GarminService implements ApplicationListener<ParticipantUpdateEvent
                 try {
                     sendDeregistration();
                     LOG.info("Successfully sent deregistration to Garmin for studyId={}, participantId={}", studyId, participantId);
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     LOG.error("Failed to send deregistration to Garmin for studyId={}, participantId={}, but continuing with local cleanup", studyId, participantId, e);
                 }
             } else {
@@ -319,7 +319,7 @@ public class GarminService implements ApplicationListener<ParticipantUpdateEvent
             List<String> permissions = response.getPermissions();
             LOG.debug("Received Garmin permissions count={}", permissions != null ? permissions.size() : 0);
             return permissions;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             LOG.error("Could not get Garmin user permissions via UserControllerApi", e);
             return Collections.emptyList();
         }
@@ -367,7 +367,7 @@ public class GarminService implements ApplicationListener<ParticipantUpdateEvent
                     LOG.debug("Deregistering non-active participant: studyId={}, participantId={}", participantKeyValue.studyId(), participantKeyValue.participantId());
                     deregisterParticipant(participantKeyValue.studyId(), participantKeyValue.participantId());
                     LOG.info("Successfully deregistered non-active participant: studyId={}, participantId={}", participantKeyValue.studyId(), participantKeyValue.participantId());
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     LOG.error("Failed to deregister non-active participant: studyId={}, participantId={}: {}", participantKeyValue.studyId(), participantKeyValue.participantId(), e.toString());
                 }
             });

--- a/src/main/java/io/redlink/more/data/service/observations/ObservationComponent.java
+++ b/src/main/java/io/redlink/more/data/service/observations/ObservationComponent.java
@@ -1,0 +1,28 @@
+package io.redlink.more.data.service.observations;
+
+import io.redlink.more.data.model.CallbackResult;
+import io.redlink.more.data.model.Observation;
+import io.redlink.more.data.model.RoutingInfo;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+public interface ObservationComponent {
+    String getObservationType();
+
+    Optional<String> produceUrl(Observation observation, RoutingInfo routingInfo, Instant scheduleStart, Instant scheduleEnd);
+
+    /**
+     * Checks if the callback parameters are sufficient to determine the completion of the observation.
+     */
+    boolean necessaryCallbackParameters(Map<String, String> parameters);
+
+    /**
+     * Processes the callback from a completed observation.
+     *
+     * @param parameters The callback request parameters.
+     * @return An optional callback result containing the updated routing information and the observation ID.
+     */
+    Optional<CallbackResult> processCallback(Map<String, String> parameters);
+}

--- a/src/main/java/io/redlink/more/data/service/observations/limesurvey/LimeSurveyComponent.java
+++ b/src/main/java/io/redlink/more/data/service/observations/limesurvey/LimeSurveyComponent.java
@@ -1,0 +1,235 @@
+package io.redlink.more.data.service.observations.limesurvey;
+
+import io.redlink.more.data.model.CallbackResult;
+import io.redlink.more.data.model.DataPoint;
+import io.redlink.more.data.model.Observation;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.model.RoutingInfoWithObservation;
+import io.redlink.more.data.service.ElasticService;
+import io.redlink.more.data.service.StudyService;
+import io.redlink.more.data.service.observations.ObservationComponent;
+import io.redlink.more.data.service.observations.limesurvey.model.ParticipantData;
+import io.redlink.more.data.util.DateTimeUtils;
+import io.redlink.more.data.util.MapperUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class LimeSurveyComponent implements ObservationComponent {
+    private static final String LIME_SURVEY_USER_TEMPLATE = "study_%s-observation_%s-participant_%s";
+
+    private static final Logger LOG = LoggerFactory.getLogger(LimeSurveyComponent.class);
+    private static final String LIME_SURVEY_ID_KEY = "limeSurveyId";
+    private static final String LIME_SURVEY_TOKEN_KEY = "token";
+    private static final String LIME_SURVEY_URL_KEY = "limeUrl";
+
+    private static final String[] LIME_SURVEY_ID_RESPONSE_KEYS = {"surveyId", "survey-id", "surveyid"};
+    private static final String[] LIME_SURVEY_SAVE_ID_KEYS = {"savedId", "savedid", "saveId"};
+    private static final String[] STUDY_ID_KEYS = {"studyId", "study-id", "studyid"};
+
+    private final LimeSurveyRequestService limeSurveyRequestService;
+    private final ElasticService elasticService;
+    private final StudyService studyService;
+
+    public LimeSurveyComponent(LimeSurveyRequestService limeSurveyRequestService, ElasticService elasticService, StudyService studyService) {
+        this.limeSurveyRequestService = limeSurveyRequestService;
+        this.elasticService = elasticService;
+        this.studyService = studyService;
+    }
+
+    @Override
+    public String getObservationType() {
+        return "lime-survey-observation";
+    }
+
+    @Override
+    public Optional<String> produceUrl(Observation observation, RoutingInfo routingInfo, Instant scheduleStart, Instant scheduleEnd) {
+        return generateLimeSurveyUrl(observation);
+    }
+
+    @Override
+    public boolean necessaryCallbackParameters(Map<String, String> parameters) {
+        return MapperUtils.containsParameter(parameters, STUDY_ID_KEYS)
+                && MapperUtils.containsParameter(parameters, LIME_SURVEY_TOKEN_KEY)
+                && MapperUtils.containsParameter(parameters, LIME_SURVEY_ID_RESPONSE_KEYS)
+                && MapperUtils.containsParameter(parameters, LIME_SURVEY_SAVE_ID_KEYS);
+    }
+
+    @Override
+    public Optional<CallbackResult> processCallback(Map<String, String> parameters) {
+        Optional<Long> studyIdParam = Optional.ofNullable(MapperUtils.getParameter(parameters, STUDY_ID_KEYS))
+                .map(Long::parseLong);
+        String token = MapperUtils.getParameter(parameters, LIME_SURVEY_TOKEN_KEY);
+        Optional<Integer> savedId = Optional.ofNullable(MapperUtils.getParameter(parameters, LIME_SURVEY_SAVE_ID_KEYS))
+                .map(Integer::parseInt);
+        Optional<Integer> surveyId = Optional.ofNullable(MapperUtils.getParameter(parameters, LIME_SURVEY_ID_RESPONSE_KEYS))
+                .map(Integer::parseInt);
+
+        if (studyIdParam.isEmpty() || token == null || savedId.isEmpty() || surveyId.isEmpty()) {
+            LOG.warn("Missing parameters for LimeSurvey Component: studyId={}, token={}, savedId={}, surveyId={}", studyIdParam, token, savedId, surveyId);
+            throw new IllegalArgumentException("Necessary parameter not provided! Please provide all of these: studyID, observationId, token!");
+        }
+
+        RoutingInfoWithObservation routingInfoAndObservationId = limeSurveyRequestService.getParticipant(token, surveyId.get())
+                .flatMap(this::lsParticipantToRoutingInfo)
+                .or(() -> studyService.getRoutingInfoByToken(studyIdParam.get(), token))
+                .orElseThrow(() -> {
+                    LOG.warn("Could not find participant for LimeSurvey Component: studyId={}, token={}, savedId={}, surveyId={}", studyIdParam, token, savedId, surveyId);
+                    return new IllegalArgumentException("Could not find participant for LimeSurvey Component for provided parameters");
+                });
+
+        RoutingInfo routingInfo = routingInfoAndObservationId.routingInfo();
+        Integer resolvedObservationId = routingInfoAndObservationId.observationId();
+
+        if (routingInfo == null || resolvedObservationId == null) {
+            LOG.warn("Could not find RoutingInfo for LimeSurvey Component: studyId={}, token={}, savedId={}, surveyId={}", studyIdParam, token, savedId, surveyId);
+            throw new IllegalArgumentException("Could not find RoutingInfo for LimeSurvey Component for provided parameters");
+        }
+
+        if (storeAnswer(surveyId.get(), savedId.get(), token, routingInfo, Integer.toString(resolvedObservationId))) {
+            LOG.debug("Stored LimeSurvey answer for survey {}, token {}, observation {}", surveyId.get(), token, resolvedObservationId);
+            return Optional.of(new CallbackResult(routingInfo, resolvedObservationId));
+        }
+        LOG.warn("Failed to store LimeSurvey answer for survey {}, token {}, observation {}", surveyId.get(), token, resolvedObservationId);
+        return Optional.empty();
+    }
+
+    private Optional<String> generateLimeSurveyUrl(Observation observation) {
+        var props = observation.properties();
+        if (!(props instanceof Map<?, ?> properties)) {
+            LOG.warn("Observation properties are not a Map! {}", props);
+            return Optional.empty();
+        }
+
+        String surveyId = asString(properties.get(LIME_SURVEY_ID_KEY));
+        String surveyToken = asString(properties.get(LIME_SURVEY_TOKEN_KEY));
+        String surveyUrl = limeSurveyRequestService.getBaseUrl()
+                .orElse(asString(properties.get(LIME_SURVEY_URL_KEY)));
+
+        return formatLimeSurveyDeepLink(surveyId, surveyToken, surveyUrl);
+    }
+
+    private static String asString(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static Optional<String> formatLimeSurveyDeepLink(String surveyId, String surveyToken, String surveyUrl) {
+        if (surveyId == null || surveyId.isBlank() || surveyToken == null || surveyToken.isBlank() || surveyUrl == null || surveyUrl.isBlank()) {
+            throw new IllegalStateException("Lime survey token, ID or url is empty!");
+        }
+
+        String base = surveyUrl.startsWith("http") ? surveyUrl : "https://" + surveyUrl;
+        String normalizedBase = base.endsWith("/") ? base : base + "/";
+        String encodedToken = URLEncoder.encode(surveyToken, StandardCharsets.UTF_8);
+
+        try {
+            URI baseUri = URI.create(normalizedBase);
+            URI result = new URI(
+                    baseUri.getScheme(),
+                    baseUri.getAuthority(),
+                    baseUri.getPath() + surveyId,
+                    LIME_SURVEY_TOKEN_KEY + "=" + encodedToken,
+                    null
+            );
+            return Optional.of(result.toString());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(
+                    String.format("Could not create Uri for lime survey %s, with survey id %s", surveyUrl, surveyId),
+                    e
+            );
+        }
+    }
+
+    private boolean storeAnswer(Integer surveyId, Integer saveId, String token, RoutingInfo routingInfo, String observationId) {
+        Optional<Map<String, Object>> answerOpt = limeSurveyRequestService.getAnswer(token, surveyId, saveId);
+        if (answerOpt.isPresent() && !answerOpt.get().isEmpty()) {
+            LOG.info("Received answer for LimeSurvey survey {}, routingInfo {}, savedId {}", surveyId, routingInfo, saveId);
+            Map<String, Object> answer = answerOpt.get();
+            Object submitDateObj = answer.remove("submitdate");
+            Instant dateSubmitted = Optional
+                    .ofNullable(submitDateObj)
+                    .map(Object::toString)
+                    .map(obj -> DateTimeUtils.parseInstantWithOffset(obj, ZoneOffset.UTC))
+                    .orElse(Instant.now());
+            DataPoint dataPoint = new DataPoint(
+                    UUID.randomUUID().toString(),
+                    observationId,
+                    getObservationType(),
+                    getObservationType(),
+                    Instant.now(),
+                    dateSubmitted,
+                    answer
+            );
+
+            try {
+                elasticService.storeDataPoints(List.of(dataPoint), routingInfo);
+                LOG.info("Stored LimeSurvey answer for survey {}, token {}, observation {}", surveyId, token, observationId);
+                return true;
+            } catch (IOException e) {
+                LOG.error("Error storing LimeSurvey answers: {}", e.toString());
+            }
+        } else {
+            LOG.warn("Could not fetch answer for LimeSurvey survey {}, token {}, savedId {}, routingInfo {}", surveyId, token, saveId, routingInfo);
+        }
+        return false;
+    }
+
+    private Optional<RoutingInfoWithObservation> lsParticipantToRoutingInfo(ParticipantData participantData) {
+        if (participantData == null || participantData.firstname() == null) {
+            LOG.warn("Could not map participant data to RoutingInfo: {}", participantData);
+            return Optional.empty();
+        }
+
+        String firstname = participantData.firstname();
+
+        if (firstname.matches("\\d+")) {
+            LOG.warn("Could not map LimeSurvey firstname to RoutingInfo as it conforms to the old format: {}", participantData);
+            return Optional.empty();
+        }
+
+        String pattern = LIME_SURVEY_USER_TEMPLATE
+                .replace("%s", "(\\d+)")
+                .replace("study_", "^study_")
+                .replace("-participant_", "-participant_") + "$";
+
+        Matcher matcher = Pattern.compile(pattern).matcher(firstname);
+        if (!matcher.matches()) {
+            LOG.warn("Could not map LimeSurvey firstname to RoutingInfo: {}", firstname);
+            return Optional.empty();
+        }
+
+        long studyId = Long.parseLong(matcher.group(1));
+        int observationId = Integer.parseInt(matcher.group(2));
+        int participantId = Integer.parseInt(matcher.group(3));
+
+        if (studyId <= 0 || observationId <= 0 || participantId <= 0) {
+            LOG.warn("Could not map LimeSurvey firstname to RoutingInfo: {}", firstname);
+            return Optional.empty();
+        }
+
+        RoutingInfo routingInfo = studyService.getRoutingInfo(studyId, participantId)
+                .orElse(null);
+
+        if (routingInfo == null) {
+            LOG.warn("Could not find RoutingInfo for LimeSurvey participant data: {}", participantData);
+            return Optional.empty();
+        }
+
+        return Optional.of(new RoutingInfoWithObservation(routingInfo, observationId));
+    }
+}

--- a/src/main/java/io/redlink/more/data/service/observations/limesurvey/LimeSurveyRequestService.java
+++ b/src/main/java/io/redlink/more/data/service/observations/limesurvey/LimeSurveyRequestService.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.service.observations.limesurvey;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.redlink.more.data.limesurvey.client.LimeSurveyRcApi;
+import io.redlink.more.data.limesurvey.model.LimeSurveyMethod;
+import io.redlink.more.data.limesurvey.model.LimeSurveyObjectResponse;
+import io.redlink.more.data.limesurvey.model.LimeSurveyRequest;
+import io.redlink.more.data.service.observations.limesurvey.config.LimeSurveyProperties;
+import io.redlink.more.data.service.observations.limesurvey.model.ParticipantData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+public class LimeSurveyRequestService {
+    private static final String LIME_NULL_DATE = "1980-01-01 00:00:00";
+    private static final DateTimeFormatter LIME_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter OFFSET_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private static final Logger LOGGER = LoggerFactory.getLogger(LimeSurveyRequestService.class);
+
+    private final LimeSurveyRcApi limeSurveyRcApi;
+    private final LimeSurveyProperties properties;
+
+    public LimeSurveyRequestService(LimeSurveyRcApi limeSurveyRcApi, LimeSurveyProperties properties) {
+        this.limeSurveyRcApi = limeSurveyRcApi;
+        this.properties = properties;
+    }
+
+    private LimeSurveyRequest createRequest(LimeSurveyMethod method, Object... params) {
+        return new LimeSurveyRequest()
+                .method(method)
+                .params(List.of(params))
+                .id(1)
+                .jsonrpc(LimeSurveyRequest.JsonrpcEnum._2_0);
+    }
+
+    public Optional<String> getBaseUrl() {
+        return Optional.ofNullable(properties.getBaseUrl());
+    }
+
+    public String getLanguage(String surveyId, String sessionKey) {
+        LimeSurveyObjectResponse response = limeSurveyRcApi.callMethod(
+                createRequest(LimeSurveyMethod.GET_LANGUAGE_PROPERTIES, sessionKey, surveyId, List.of("surveyls_language"))
+        );
+
+        if (response == null) {
+            throw new RuntimeException("Error reading language for survey " + surveyId + ": Response is null");
+        }
+        if (response.getError() != null && !response.getError().isBlank()) {
+            throw new RuntimeException("Error reading language for survey " + surveyId + ": " + response.getError());
+        }
+
+        Object result = response.getResult();
+        if (result instanceof Map<?, ?> resultMap) {
+            Object status = resultMap.get("status");
+            if (status != null) {
+                throw new RuntimeException("Error reading language for survey " + surveyId + ": " + status);
+            }
+            Object lang = resultMap.get("surveyls_language");
+            if (lang != null) {
+                return String.valueOf(lang);
+            }
+        }
+
+        throw new IllegalStateException("Missing survey language for survey " + surveyId + " (result=" + result + ")");
+    }
+
+    private String getSessionKey() {
+        try {
+            var response = limeSurveyRcApi.callMethod(createRequest(LimeSurveyMethod.GET_SESSION_KEY, properties.getUsername(), properties.getPassword()));
+            if (response == null) {
+                throw new RuntimeException("Error retrieving session key: Response is null");
+            }
+            if (response.getError() != null && !response.getError().isBlank()) {
+                throw new RuntimeException("Error retrieving session key: " + response.getError());
+            }
+
+            if (response.getResult() == null) {
+                throw new RuntimeException("LimeSurvey remote control returned no session key response.");
+            }
+
+            Object result = response.getResult();
+            if (result instanceof Map<?, ?> resultMap) {
+                Object status = resultMap.get("status");
+                if (status != null) {
+                    throw new RuntimeException("Error retrieving session key from LimeSurvey: " + status);
+                }
+            }
+
+            if (!(result instanceof String key) || key.trim().isBlank()) {
+                LOGGER.error("LimeSurvey remote control returned an invalid session key payload. remoteUrl={}, rawResponse={}", properties.getBaseUrl(), response);
+                throw new RuntimeException("LimeSurvey returned an empty or invalid session key.");
+            }
+            if (key.contains("Invalid user name or password")) {
+                throw new RuntimeException("Not possible to get session key for Limesurvey because of invalid credentials.");
+            } else if (key.contains("You have exceeded the number of maximum login attempts. Please wait 10 minutes before trying again")) {
+                throw new RuntimeException("Too many login attempts for Limesurvey. Try again in 10 minutes.");
+            }
+
+
+            return key.trim();
+        } catch (RestClientException e) {
+            LOGGER.error("Timeout while getting session key from Limesurvey remote control at {}", properties.getBaseUrl(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void releaseSessionKey(String sessionKey) {
+        if (sessionKey == null || sessionKey.isBlank()) {
+            return;
+        }
+        try {
+            limeSurveyRcApi.callMethod(createRequest(LimeSurveyMethod.RELEASE_SESSION_KEY, sessionKey));
+
+        } catch (RestClientException e) {
+            LOGGER.error("Error releasing session key for Limesurvey remote control", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void releaseSessionKeyQuietly(String sessionKey) {
+        if (sessionKey == null || sessionKey.isBlank()) {
+            return;
+        }
+        try {
+            releaseSessionKey(sessionKey);
+        } catch (RuntimeException e) {
+            LOGGER.warn("Could not release session key cleanly", e);
+        }
+    }
+
+    public Optional<ParticipantData> getParticipant(String token, int surveyId) {
+        if (token == null || token.isBlank() || surveyId <= 0) {
+            LOGGER.warn("Invalid participant query parameters: surveyId={}, token={}", surveyId, token);
+            return Optional.empty();
+        }
+        String sessionKey = null;
+
+        try {
+            sessionKey = getSessionKey();
+            var response = limeSurveyRcApi.callMethod(
+                    createRequest(
+                            LimeSurveyMethod.GET_PARTICIPANT_PROPERTIES,
+                            sessionKey,
+                            surveyId,
+                            Map.of("token", token),
+                            List.of("tid", "token", "participant_info", "firstname", "lastname", "email")
+                    )
+            );
+
+            if (response == null) {
+                LOGGER.warn("LimeSurvey returned null response for get_participant_properties (surveyId={})", surveyId);
+                return Optional.empty();
+            }
+            if (response.getError() != null && !response.getError().isBlank()) {
+                LOGGER.warn("LimeSurvey returned error for get_participant_properties (surveyId={}): {}", surveyId, response.getError());
+                return Optional.empty();
+            }
+            if (response.getResult() == null) {
+                LOGGER.warn("LimeSurvey returned null result for get_participant_properties (surveyId={})", surveyId);
+                return Optional.empty();
+            }
+
+            Object result = response.getResult();
+            if (result instanceof Map<?, ?> resultMap && resultMap.get("status") != null) {
+                LOGGER.warn("LimeSurvey returned status for get_participant_properties (surveyId={}): {}", surveyId, resultMap.get("status"));
+                return Optional.empty();
+            }
+
+            return Optional.of(mapper.convertValue(result, ParticipantData.class));
+        } catch (IllegalArgumentException e) {
+            LOGGER.error("Could not map LimeSurvey participant data for surveyId={} and token={}", surveyId, token, e);
+            return Optional.empty();
+        } catch (RuntimeException e) {
+            LOGGER.error("Could not get participant from LimeSurvey remote control", e);
+            return Optional.empty();
+        } finally {
+            releaseSessionKeyQuietly(sessionKey);
+        }
+    }
+
+    public Optional<Map<String, Object>> getAnswer(String token, int surveyId, int savedId) {
+        return getAnswer(token, surveyId, savedId, "code", "short");
+    }
+
+    public Optional<Map<String, Object>> getAnswerPlaintext(String token, int surveyId, int savedId) {
+        return getAnswer(token, surveyId, savedId, "full", "long");
+    }
+
+    private Optional<Map<String, Object>> getAnswer(String token, int surveyId, int savedId, String headingType, String responseType) {
+        if (token == null || token.isBlank() || surveyId <= 0 || savedId <= 0) {
+            LOGGER.warn("Invalid answer query parameters: surveyId={}, savedId={}", surveyId, savedId);
+            return Optional.empty();
+        }
+
+        String sessionKey = null;
+        try {
+            sessionKey = getSessionKey();
+            String lang = getLanguage(String.valueOf(surveyId), sessionKey);
+            var apiResponse = limeSurveyRcApi.callMethod(createRequest(LimeSurveyMethod.EXPORT_RESPONSES_BY_TOKEN, sessionKey, surveyId, "json", token, lang, "all", headingType, responseType));
+
+            if (apiResponse == null) {
+                LOGGER.warn("LimeSurvey returned null response for export_responses_by_token (surveyId={})", surveyId);
+                return Optional.empty();
+            }
+            if (apiResponse.getError() != null && !apiResponse.getError().isBlank()) {
+                LOGGER.warn("LimeSurvey returned error for export_responses_by_token (surveyId={}): {}", surveyId, apiResponse.getError());
+                return Optional.empty();
+            }
+
+            if (apiResponse.getResult() == null) {
+                LOGGER.warn("LimeSurvey returned null result for export_responses_by_token (surveyId={})", surveyId);
+                return Optional.empty();
+            }
+            JsonNode result = mapper.readTree(Base64.getDecoder().decode(apiResponse.getResult().toString()));
+            JsonNode responsesNode = result.path("responses");
+            if (!responsesNode.isArray()) {
+                LOGGER.warn("Limesurvey returned no responses (surveyId={}): {}", surveyId, result.asText());
+                return Optional.empty();
+            }
+
+            Iterator<JsonNode> responses = responsesNode.elements();
+            while (responses.hasNext()) {
+                JsonNode response = responses.next();
+                if (response == null || !response.isObject()) {
+                    continue;
+                }
+
+                Map<String, Object> answer = mapper.convertValue(response, Map.class);
+                //NOTE: Do not store the survey token
+                answer.remove("token");
+                answer.values().removeIf(obj -> Objects.isNull(obj) || obj.equals(token));
+
+                normalizeDateFields(answer);
+
+                Object responseId = answer.get("Response ID");
+                Object id = answer.get("id");
+                boolean matchesSavedId = Objects.equals(String.valueOf(savedId), String.valueOf(responseId))
+                        || Objects.equals(String.valueOf(savedId), String.valueOf(id));
+
+                if (matchesSavedId || responsesNode.size() == 1) {
+                    return Optional.of(new HashMap<>(answer));
+                }
+            }
+            return Optional.empty();
+        } catch (IllegalArgumentException e) {
+            LOGGER.error("Could not decode LimeSurvey response payload for survey {} and savedId {}", surveyId, savedId, e);
+            return Optional.empty();
+        } catch (RestClientException e) {
+            LOGGER.error("Error reading results for {}", surveyId, e);
+            return Optional.empty();
+        } catch (IOException e) {
+            LOGGER.error("Could not decode queried result data for survey {}, saveId {}", surveyId, savedId, e);
+            throw new RuntimeException(e);
+        } finally {
+            releaseSessionKeyQuietly(sessionKey);
+        }
+    }
+
+    private void normalizeDateFields(Map<String, Object> answer) {
+        answer.replaceAll((key, value) -> {
+            if (value == null || !isDateField(key)) {
+                return value;
+            }
+
+            String dateValue = String.valueOf(value);
+            if (LIME_NULL_DATE.equals(dateValue)) {
+                return LocalDateTime.now(ZoneOffset.UTC)
+                        .atOffset(ZoneOffset.UTC)
+                        .format(OFFSET_DATE_TIME_FORMATTER);
+            }
+
+            var normalized = normalizeDateTimeString(dateValue);
+            if (normalized.isPresent()) {
+                return normalized.get();
+            }
+            return value;
+        });
+    }
+
+    private boolean isDateField(String key) {
+        if (key == null) {
+            return false;
+        }
+        String normalizedKey = key.toLowerCase();
+        return normalizedKey.contains("date") || normalizedKey.contains("datestamp") || normalizedKey.contains("timestamp");
+    }
+
+    private Optional<String> normalizeDateTimeString(String value) {
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(
+                    LocalDateTime.parse(value, LIME_DATE_FORMATTER)
+                            .atOffset(ZoneOffset.UTC)
+                            .format(OFFSET_DATE_TIME_FORMATTER)
+            );
+        } catch (DateTimeParseException e) {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/src/main/java/io/redlink/more/data/service/observations/limesurvey/config/LimeSurveyConfiguration.java
+++ b/src/main/java/io/redlink/more/data/service/observations/limesurvey/config/LimeSurveyConfiguration.java
@@ -1,0 +1,31 @@
+package io.redlink.more.data.service.observations.limesurvey.config;
+
+import io.redlink.more.data.limesurvey.client.LimeSurveyRcApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Configuration
+public class LimeSurveyConfiguration {
+
+    private final LimeSurveyProperties limeSurveyProperties;
+
+    public LimeSurveyConfiguration(LimeSurveyProperties limeSurveyProperties) {
+        this.limeSurveyProperties = limeSurveyProperties;
+    }
+
+    @Bean
+    public LimeSurveyRcApi limeSurveyRcApi() {
+        LimeSurveyRcApi api = new LimeSurveyRcApi();
+        if (StringUtils.hasText(limeSurveyProperties.getBaseUrl())) {
+            String defaultBasePath = api.getApiClient().getBasePath();
+            String path = UriComponentsBuilder.fromUriString(defaultBasePath).build().getPath();
+            String newBasePath = UriComponentsBuilder.fromUriString(limeSurveyProperties.getBaseUrl())
+                    .path(path)
+                    .build().toUriString();
+            api.getApiClient().setBasePath(newBasePath);
+        }
+        return api;
+    }
+}

--- a/src/main/java/io/redlink/more/data/service/observations/limesurvey/config/LimeSurveyProperties.java
+++ b/src/main/java/io/redlink/more/data/service/observations/limesurvey/config/LimeSurveyProperties.java
@@ -1,0 +1,36 @@
+package io.redlink.more.data.service.observations.limesurvey.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "more.limesurvey")
+public class LimeSurveyProperties {
+    private String username;
+    private String password;
+    private String baseUrl;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/src/main/java/io/redlink/more/data/service/observations/limesurvey/model/ParticipantData.java
+++ b/src/main/java/io/redlink/more/data/service/observations/limesurvey/model/ParticipantData.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.service.observations.limesurvey.model;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ParticipantData(
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String token,
+        Integer tid,
+        String firstname,
+        String lastname,
+        String email
+) {
+
+    @Override
+    public String toString() {
+        return "ParticipantData{" +
+                "firstname='" + firstname + '\'' +
+                ", lastname='" + lastname + '\'' +
+                ", token='" + token + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/io/redlink/more/data/store/observationCallback/InMemoryObservationCallbackStore.java
+++ b/src/main/java/io/redlink/more/data/store/observationCallback/InMemoryObservationCallbackStore.java
@@ -1,0 +1,81 @@
+package io.redlink.more.data.store.observationCallback;
+
+import io.redlink.more.data.model.ActiveObservation;
+import io.redlink.more.data.model.CompletedData;
+import io.redlink.more.data.model.RoutingInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@ConditionalOnMissingBean(
+        value = ObservationCallbackStore.class,
+        ignored = InMemoryObservationCallbackStore.class
+)
+public class InMemoryObservationCallbackStore implements ObservationCallbackStore {
+    private static final Logger LOG = LoggerFactory.getLogger(InMemoryObservationCallbackStore.class);
+    private final Map<String, Map<ActiveObservation, String>> externalRedirects = new ConcurrentHashMap<>();
+    private final Map<String, List<CompletedData>> completedDataMap = new ConcurrentHashMap<>();
+
+    @Override
+    public void saveRedirect(RoutingInfo routingInfo, ActiveObservation activeObservation, String redirect) {
+        this.externalRedirects.computeIfAbsent(routingInfo.participantRef(), k -> Collections.synchronizedMap(new LinkedHashMap<>()))
+                .put(activeObservation, redirect);
+    }
+
+    @Override
+    public Optional<URI> pullRedirect(RoutingInfo routingInfo, int observationId) {
+        if (routingInfo == null) {
+            LOG.warn("RoutingInfo is null, cannot pull redirect for observationId: {}", observationId);
+            throw new IllegalArgumentException("RoutingInfo may not be null for getting redirects!");
+        }
+        var observationWithRedirect = externalRedirects.getOrDefault(routingInfo.participantRef(), Collections.emptyMap());
+        LOG.debug("Found {} external redirects for participant {}", observationWithRedirect.size(), routingInfo.participantRef());
+        var lastActiveObservation = observationWithRedirect.keySet().stream()
+                .filter(ao -> Integer.parseInt(ao.observationId()) == observationId)
+                .findFirst();
+        if (lastActiveObservation.isPresent()) {
+            LOG.debug("Found redirect for observationId: {}", observationId);
+            String externalRedirect = observationWithRedirect.remove(lastActiveObservation.get());
+            markCompleted(routingInfo, lastActiveObservation.get());
+            if (observationWithRedirect.isEmpty()) {
+                externalRedirects.remove(routingInfo.participantRef());
+            } else {
+                externalRedirects.put(routingInfo.participantRef(), observationWithRedirect);
+            }
+            if (externalRedirect != null && !externalRedirect.isBlank()) {
+                LOG.debug("Redirecting to {}", externalRedirect);
+                return Optional.of(URI.create(externalRedirect));
+            }
+        }
+        LOG.warn("No redirect found for observationId: {}", observationId);
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean isCompleted(RoutingInfo routingInfo, ActiveObservation activeObservation) {
+        return completedDataMap.getOrDefault(routingInfo.participantRef(), Collections.emptyList())
+                .contains(CompletedData.fromActiveObservation(activeObservation));
+    }
+
+    @Override
+    public void markCompleted(RoutingInfo routingInfo, ActiveObservation activeObservation) {
+        completedDataMap.computeIfAbsent(routingInfo.participantRef(), k -> Collections.synchronizedList(new LinkedList<>()))
+                .add(CompletedData.fromActiveObservation(activeObservation));
+    }
+
+    @Override
+    public List<CompletedData> getCompletedData(RoutingInfo routingInfo) {
+        return completedDataMap.getOrDefault(routingInfo.participantRef(), Collections.emptyList());
+    }
+}

--- a/src/main/java/io/redlink/more/data/store/observationCallback/ObservationCallbackStore.java
+++ b/src/main/java/io/redlink/more/data/store/observationCallback/ObservationCallbackStore.java
@@ -1,0 +1,21 @@
+package io.redlink.more.data.store.observationCallback;
+
+import io.redlink.more.data.model.ActiveObservation;
+import io.redlink.more.data.model.CompletedData;
+import io.redlink.more.data.model.RoutingInfo;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+public interface ObservationCallbackStore {
+    void saveRedirect(RoutingInfo routingInfo, ActiveObservation activeObservation, String redirect);
+
+    Optional<URI> pullRedirect(RoutingInfo routingInfo, int observationId);
+
+    boolean isCompleted(RoutingInfo routingInfo, ActiveObservation activeObservation);
+
+    void markCompleted(RoutingInfo routingInfo, ActiveObservation activeObservation);
+
+    List<CompletedData> getCompletedData(RoutingInfo routingInfo);
+}

--- a/src/main/java/io/redlink/more/data/util/DateTimeUtils.java
+++ b/src/main/java/io/redlink/more/data/util/DateTimeUtils.java
@@ -3,8 +3,13 @@ package io.redlink.more.data.util;
 import org.apache.commons.lang3.Range;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -59,5 +64,50 @@ public class DateTimeUtils {
         }
         merged.add(current);
         return new HashSet<>(merged);
+    }
+
+    public static Instant parseInstant(String source) {
+        if (source == null || source.isBlank()) {
+            return null;
+        }
+
+        ZoneOffset systemOffset = ZoneId.systemDefault()
+                .getRules()
+                .getOffset(LocalDateTime.now());
+
+        return parseInstantWithOffset(source, systemOffset);
+    }
+
+    /**
+     * Parses an Instant from a string representation, considering a specific timezone offset.
+     *
+     * @param source     The string representation of the Instant.
+     * @param zoneOffset The timezone offset.
+     * @return The parsed Instant or null if the source is null or blank.
+     */
+    public static Instant parseInstantWithOffset(String source, ZoneOffset zoneOffset) {
+        if (source == null || source.isBlank()) {
+            return null;
+        }
+
+        try {
+            return Instant.parse(source);
+        } catch (DateTimeParseException e) {
+            try {
+                return LocalDate.parse(source)
+                        .atStartOfDay()
+                        .atOffset(zoneOffset)
+                        .toInstant();
+            } catch (DateTimeParseException e2) {
+                try {
+                    // Handle format: "yyyy-MM-dd HH:mm:ss"
+                    return LocalDateTime.parse(source, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+                            .atOffset(zoneOffset)
+                            .toInstant();
+                } catch (DateTimeParseException e3) {
+                    throw new IllegalArgumentException("Invalid date format: " + source, e);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/io/redlink/more/data/util/MapperUtils.java
+++ b/src/main/java/io/redlink/more/data/util/MapperUtils.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.redlink.more.data.exception.BadRequestException;
 import io.redlink.more.data.model.Alias;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,5 +56,25 @@ public class MapperUtils {
                 || value instanceof Boolean
                 || value instanceof Character
                 || value instanceof Enum<?>;
+    }
+
+    public static String getParameter(Map<String, String> parameters, String... keys) {
+        for (String key : keys) {
+            if (parameters.containsKey(key)) {
+                return parameters.get(key);
+            }
+        }
+        for (String key : keys) {
+            for (Map.Entry<String, String> entry : parameters.entrySet()) {
+                if (entry.getKey().equalsIgnoreCase(key)) {
+                    return entry.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    public static boolean containsParameter(Map<String, String> parameters, String... keys) {
+        return Arrays.stream(keys).anyMatch(parameters::containsKey);
     }
 }

--- a/src/main/java/io/redlink/more/data/util/ParticipantUtils.java
+++ b/src/main/java/io/redlink/more/data/util/ParticipantUtils.java
@@ -1,0 +1,93 @@
+package io.redlink.more.data.util;
+
+import io.redlink.more.data.model.ParticipantConsent;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class ParticipantUtils {
+    public static ParticipantConsent convert(io.redlink.more.data.api.participant.v1.model.StudyConsentDTO dto) {
+        return new ParticipantConsent(
+                dto.getConsent(),
+                obfuscate(dto.getDeviceId()),
+                dto.getConsentInfoMD5(),
+                null,
+                convertParticipantObservations(dto.getObservations())
+        );
+    }
+
+    public static ParticipantConsent convert(io.redlink.more.data.api.app.v1.model.StudyConsentDTO dto) {
+        return new ParticipantConsent(
+                dto.getConsent(),
+                obfuscate(dto.getDeviceId()),
+                dto.getConsentInfoMD5(),
+                null,
+                convertAppObservations(dto.getObservations())
+        );
+    }
+
+    /**
+     * Device-ID has the format "[MODEL]#[SERIAL], we obfuscate to [MODEL]#[SERIAL:0:6]...[SERIAL:-6:-0]
+     */
+    static String obfuscate(String string) {
+        final String unknown = "unknown";
+        if (StringUtils.isBlank(string)) return unknown;
+
+        final int keepChars = 6;
+        final int delim = string.indexOf('#');
+        if (delim < 0) {
+            // No delimiter found, handle as whole string
+            if (string.length() <= keepChars * 2) {
+                return string;
+            }
+            return "%s...%s".formatted(
+                    StringUtils.left(string, keepChars),
+                    StringUtils.right(string, keepChars)
+            );
+        }
+
+        String model = StringUtils.left(string, delim);
+        String serial = StringUtils.substring(string, delim + 1);
+
+        if (serial.length() <= keepChars * 2) {
+            return "%s#%s".formatted(
+                    StringUtils.defaultIfEmpty(model, unknown),
+                    serial
+            );
+        }
+
+        return "%s#%s...%s".formatted(
+                StringUtils.defaultIfEmpty(model, unknown),
+                StringUtils.left(serial, keepChars),
+                StringUtils.right(serial, keepChars)
+        );
+    }
+
+    private static List<ParticipantConsent.ObservationConsent> convertAppObservations(List<io.redlink.more.data.api.app.v1.model.ObservationConsentDTO> observations) {
+        return Optional.ofNullable(observations).orElse(Collections.emptyList()).stream()
+                .map(ParticipantUtils::convert)
+                .toList();
+    }
+
+    private static ParticipantConsent.ObservationConsent convert(io.redlink.more.data.api.app.v1.model.ObservationConsentDTO observation) {
+        return new ParticipantConsent.ObservationConsent(
+                Integer.parseInt(observation.getObservationId()),
+                null
+        );
+    }
+
+    private static List<ParticipantConsent.ObservationConsent> convertParticipantObservations(List<io.redlink.more.data.api.participant.v1.model.ObservationConsentDTO> observations) {
+        return Optional.ofNullable(observations).orElse(Collections.emptyList()).stream()
+                .map(ParticipantUtils::convert)
+                .toList();
+    }
+
+    private static ParticipantConsent.ObservationConsent convert(io.redlink.more.data.api.participant.v1.model.ObservationConsentDTO observation) {
+        return new ParticipantConsent.ObservationConsent(
+                Integer.parseInt(observation.getObservationId()),
+                null
+        );
+    }
+}

--- a/src/main/java/io/redlink/more/data/util/StringUtils.java
+++ b/src/main/java/io/redlink/more/data/util/StringUtils.java
@@ -3,6 +3,7 @@ package io.redlink.more.data.util;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 
 public class StringUtils {
     public static String anonymize(String s) {
@@ -40,5 +41,9 @@ public class StringUtils {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("SHA-256 not available", e);
         }
+    }
+
+    public static String base64Decode(String input) {
+        return new String(Base64.getDecoder().decode(input));
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,10 @@ spring:
     password: ${POSTGRES_PASSWORD:more}
     name: ${POSTGRES_DBNAME:more}
 
+  jackson:
+    # optional properties that are not set should not be included
+    default-property-inclusion: non_null
+
   session:
     store-type: redis
     redis:
@@ -29,6 +33,16 @@ server:
 more:
   gateway:
     baseUrl: ${BASE_URL:}
+
+  login-token:
+    hash-algorithm: ${LOGIN_TOKEN_HASH_ALGORITHM:SHA-256}
+  application:
+    urls:
+      PARTICIPANT_PORTAL: '${PARTICIPANT_PORTAL_URL:http://localhost:3001}'
+  limesurvey:
+    username: '${LIME_ADMIN_USER:more-admin}'
+    password: '${LIME_ADMIN_PWD:more-admin}'
+    baseUrl: '${LIME_BASE_URL:https://lime.platform-test.more.redlink.io}'
 
 elastic:
   host: ${ELASTIC_HOST:localhost}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,7 +8,6 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
-
     </springProfile>
     <springProfile name="default">
         <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
@@ -17,7 +16,7 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
-        <logger name="org.springframework.web" level="DEBUG"/>
+        <!-- <logger name="org.springframework.web" level="DEBUG"/> -->
     </springProfile>
 
 </configuration>

--- a/src/main/resources/openapi/BaseComponents.yaml
+++ b/src/main/resources/openapi/BaseComponents.yaml
@@ -1,0 +1,223 @@
+openapi: 3.0.3
+info:
+  title: Common Components API
+  version: 1.0.0
+
+paths: { }
+
+components:
+  schemas:
+    Study:
+      description:
+        The study object containing all information and observation
+        information to configure and initialize the APP
+      type: object
+      properties:
+        active:
+          description:
+            The current study-state. Mainly used during the registration process.
+          type: boolean
+          default: true
+        studyState:
+          type: string
+          enum:
+            - active
+            - preview
+            - paused
+            - closed
+        participant:
+          $ref: '#/components/schemas/SimpleParticipant'
+        studyTitle:
+          type: string
+        participantInfo:
+          type: string
+        consentInfo:
+          type: string
+        finishText:
+          type: string
+        contact:
+          $ref: '#/components/schemas/ContactInfo'
+        start:
+          type: string
+          format: date
+        end:
+          type: string
+          format: date
+        observations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Observation'
+          minItems: 1
+        version:
+          $ref: '#/components/schemas/VersionTag'
+      required:
+        - studyTitle
+        - participantInfo
+        - consentInfo
+        - start
+        - end
+        - observations
+        - version
+
+    SimpleParticipant:
+      type: object
+      properties:
+        id:
+          type: integer
+        alias:
+          type: string
+
+    ContactInfo:
+      description: Contact-Information
+      type: object
+      properties:
+        institute:
+          type: string
+        person:
+          type: string
+        email:
+          type: string
+        phoneNumber:
+          type: string
+
+    Observation:
+      description: The configuration of an observation for the study.
+      type: object
+      properties:
+        observationId:
+          type: string
+        observationType:
+          type: string
+        observationTitle:
+          type: string
+        participantInfo:
+          type: string
+        configuration:
+          type: object
+        schedule:
+          type: array
+          items:
+            title: ObservationSchedule
+            type: object
+            properties:
+              start:
+                type: string
+                format: date-time
+              end:
+                type: string
+                format: date-time
+              dataHealth:
+                $ref: '#/components/schemas/DataHealthState'
+
+        required:
+          type: boolean
+          default: true
+        hidden:
+          type: boolean
+          default: false
+        noSchedule:
+          type: boolean
+          default: false
+        reminder:
+          type: boolean
+          default: false
+        version:
+          $ref: '#/components/schemas/VersionTag'
+      required:
+        - observationId
+        - observationType
+        - observationTitle
+        - participantInfo
+        - schedule
+        - required
+        - version
+
+    VersionTag:
+      description:
+        A version indicator. Currently the last-modified date in EPOCH-format
+        but that's not guaranteed.
+      type: integer
+      format: int64
+
+    DataHealthState:
+      type: string
+      description: >
+        Data Health states:
+          * `completed` - The expected data for the observation schedule are completely availanble
+          * `incomplete` - Data for the observation schedule are available and valid, but more data is expected
+          * `missing` - No data for the observation schedule is available
+          * `invalid` - Data is available, but the data is not valid (e.g. multiple answers for a survey; 
+             wrong data format; missing required information)
+      enum:
+        - completed
+        - incomplete
+        - missing
+        - invalid
+
+    StudyConsent:
+      type: object
+      description: Confirms the participants consent to the study including supported observations on the device.
+      properties:
+        consent:
+          description: Explicitly state the consent of the Participant
+          type: boolean
+          default: false
+        deviceId:
+          description: Identifier of the device used to provide consent
+          type: string
+        consentInfoMD5:
+          description: |
+            MD5-Hash of the `consentInfo` (text) the participant
+            actually gave consent.
+          type: string
+        observations:
+          type: array
+          items:
+            title: ObservationConsent
+            type: object
+            properties:
+              observationId:
+                type: string
+              active:
+                type: boolean
+                default: true
+            required:
+              - observationId
+              - active
+      required:
+        - consent
+        - deviceId
+        - consentInfoMD5
+        - observations
+
+    ApiKey:
+      description: |
+        Credentials for the for interacting with the backends
+      type: object
+      readOnly: true
+      properties:
+        apiId:
+          type: string
+          readOnly: true
+        apiKey:
+          type: string
+          readOnly: true
+      required:
+        - apiId
+        - apiKey
+
+    Id:
+      type: string
+
+  responses:
+    StudyInfoResponse:
+      description: The Study Info
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Study'
+
+    UnauthorizedApiKey:
+      description: |
+        **Authentication Required**
+        Login is performed via `basic-auth` using `apiId` as username and `apiKey` as password.

--- a/src/main/resources/openapi/ExternalAPI.yaml
+++ b/src/main/resources/openapi/ExternalAPI.yaml
@@ -95,7 +95,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/Participant'
         '401':
-          $ref: '#/components/responses/UnauthorizedApiKey'
+          $ref: 'BaseComponents.yaml#/components/responses/UnauthorizedApiKey'
 
 components:
   schemas:
@@ -202,8 +202,3 @@ components:
         type: integer
         format: int32
       required: true
-
-  responses:
-    UnauthorizedApiKey:
-      description: Invalid/Unknown authentication Token
-

--- a/src/main/resources/openapi/LimeSurveyRemoteControlAPI.yaml
+++ b/src/main/resources/openapi/LimeSurveyRemoteControlAPI.yaml
@@ -1,0 +1,84 @@
+openapi: 3.0.3
+info:
+  title: LimeSurvey RemoteControl API
+  version: 1.0.0
+servers:
+  - url: /admin/remotecontrol
+
+tags:
+  - name: LimeSurveyRC
+paths:
+  "/":
+    post:
+      operationId: callMethod
+      summary: Generic Remote Control call
+      tags:
+        - LimeSurveyRC
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LimeSurveyRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LimeSurveyObjectResponse'
+
+components:
+  schemas:
+    LimeSurveyMethod:
+      type: string
+      description: Supported LimeSurvey RemoteControl method names
+      enum:
+        - call_method
+        - get_session_key
+        - release_session_key
+        - activate_survey
+        - stop_survey
+        - delete_participants
+        - set_language_properties
+        - get_language_properties
+        - activate_tokens
+        - add_participants
+        - list_surveys
+        - list_participants
+        - get_participant_properties
+        - export_responses_by_token
+        - get_survey_properties
+
+    LimeSurveyRequest:
+      type: object
+      properties:
+        method:
+          $ref: '#/components/schemas/LimeSurveyMethod'
+        params:
+          type: array
+          items:
+            type: object
+        id:
+          type: integer
+        jsonrpc:
+          type: string
+          enum:
+            - "2.0"
+      required:
+        - method
+        - params
+        - id
+        - jsonrpc
+
+    LimeSurveyObjectResponse:
+      type: object
+      properties:
+        result:
+          type: object
+          nullable: true
+        error:
+          type: string
+          nullable: true
+        id:
+          type: integer

--- a/src/main/resources/openapi/MobileAppAPI.yaml
+++ b/src/main/resources/openapi/MobileAppAPI.yaml
@@ -62,7 +62,7 @@ paths:
         - $ref: '#/components/parameters/RegistrationToken'
       responses:
         '200':
-          $ref: '#/components/responses/StudyInfoResponse'
+          $ref: 'BaseComponents.yaml#/components/responses/StudyInfoResponse'
         '404':
           $ref: '#/components/responses/NoSuchRegistrationToken'
         '410':
@@ -80,7 +80,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/StudyConsent'
+              $ref: 'BaseComponents.yaml#/components/schemas/StudyConsent'
       responses:
         '201':
           description: Consent given and ApiKey created.
@@ -122,7 +122,7 @@ paths:
                 type: string
               description: URL to the Garmin OAuth page
         '401':
-          $ref: '#/components/responses/UnauthorizedApiKey'
+          $ref: 'BaseComponents.yaml#/components/responses/UnauthorizedApiKey'
 
   /registration/garmin/callback:
     get:
@@ -157,7 +157,7 @@ paths:
         '400':
           description: invalid or missing parameters
         '401':
-          $ref: '#/components/responses/UnauthorizedApiKey'
+          $ref: 'BaseComponents.yaml#/components/responses/UnauthorizedApiKey'
 
 
   /config/study:
@@ -168,9 +168,9 @@ paths:
         - Configuration
       responses:
         '200':
-          $ref: '#/components/responses/StudyInfoResponse'
+          $ref: 'BaseComponents.yaml#/components/responses/StudyInfoResponse'
         '401':
-          $ref: '#/components/responses/UnauthorizedApiKey'
+          $ref: 'BaseComponents.yaml#/components/responses/UnauthorizedApiKey'
 
   /config/notifications:
     get:
@@ -188,7 +188,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/PushNotificationServiceType'
         '401':
-          $ref: '#/components/responses/UnauthorizedApiKey'
+          $ref: 'BaseComponents.yaml#/components/responses/UnauthorizedApiKey'
 
   /config/notifications/{serviceType}:
     parameters:
@@ -210,7 +210,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PushNotificationConfig'
         '401':
-          $ref: '#/components/responses/UnauthorizedApiKey'
+          $ref: 'BaseComponents.yaml#/components/responses/UnauthorizedApiKey'
     put:
       operationId: setPushNotificationToken
       description: store the client's push-notification token
@@ -225,7 +225,7 @@ paths:
         '202':
           description: notification-token updated
         '401':
-          $ref: '#/components/responses/UnauthorizedApiKey'
+          $ref: 'BaseComponents.yaml#/components/responses/UnauthorizedApiKey'
         '404':
           description: unknown notification service
   /notifications:
@@ -278,175 +278,11 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Id'
+                  $ref: 'BaseComponents.yaml#/components/schemas/Id'
         '401':
-          $ref: '#/components/responses/UnauthorizedApiKey'
+          $ref: 'BaseComponents.yaml#/components/responses/UnauthorizedApiKey'
 components:
   schemas:
-    Study:
-      description:
-        The study object containing all information and observation
-        information to configure and initialize the APP
-      type: object
-      properties:
-        active:
-          description:
-            The current study-state. Mainly used during the registration process.
-          type: boolean
-          default: true
-        studyState:
-          type: string
-          enum:
-            - active
-            - paused
-            - closed
-        participant:
-          $ref: '#/components/schemas/SimpleParticipant'
-        studyTitle:
-          type: string
-        participantInfo:
-          type: string
-        consentInfo:
-          type: string
-        finishText:
-          type: string
-        contact:
-          $ref: '#/components/schemas/ContactInfo'
-        start:
-          type: string
-          format: date
-        end:
-          type: string
-          format: date
-        observations:
-          type: array
-          items:
-            $ref: '#/components/schemas/Observation'
-          minItems: 1
-        version:
-          $ref: '#/components/schemas/VersionTag'
-      required:
-        - studyTitle
-        - participantInfo
-        - consentInfo
-        - start
-        - end
-        - observations
-        - version
-
-    SimpleParticipant:
-      type: object
-      properties:
-        id:
-          type: integer
-        alias:
-          type: string
-
-    ContactInfo:
-      description: Contact-Information
-      type: object
-      properties:
-        institute:
-          type: string
-        person:
-          type: string
-        email:
-          type: string
-        phoneNumber:
-          type: string
-
-    Observation:
-      description: The configuration of an observation for the study.
-      type: object
-      properties:
-        observationId:
-          type: string
-        observationType:
-          type: string
-        observationTitle:
-          type: string
-        participantInfo:
-          type: string
-        configuration:
-          type: object
-        schedule:
-          type: array
-          items:
-            title: ObservationSchedule
-            type: object
-            properties:
-              start:
-                type: string
-                format: date-time
-              end:
-                type: string
-                format: date-time
-        required:
-          type: boolean
-          default: true
-        hidden:
-          type: boolean
-          default: false
-        noSchedule:
-          type: boolean
-          default: false
-        reminder:
-          type: boolean
-          default: false
-        version:
-          $ref: '#/components/schemas/VersionTag'
-      required:
-        - observationId
-        - observationType
-        - observationTitle
-        - participantInfo
-        - schedule
-        - required
-        - version
-
-    VersionTag:
-      description:
-        A version indicator. Currently the last-modified date in EPOCH-format
-        but that's not guaranteed.
-      type: integer
-      format: int64
-
-    StudyConsent:
-      type: object
-      description: Confirms the participants consent to the study including supported observations on the device.
-      properties:
-        consent:
-          description: Explicitly state the consent of the Participant
-          type: boolean
-          default: false
-        deviceId:
-          description: Identifier of the device used to provide consent
-          type: string
-        consentInfoMD5:
-          description: |
-            MD5-Hash of the `consentInfo` (text) the participant
-            actually gave consent.
-          type: string
-        observations:
-          type: array
-          items:
-            title: ObservationConsent
-            type: object
-            properties:
-              observationId:
-                type: string
-              active:
-                type: boolean
-                default: true
-            required:
-              - observationId
-              - active
-      required:
-        - consent
-        - deviceId
-        - consentInfoMD5
-        - observations
-
     PushNotification:
       description: a push notification
       type: object
@@ -484,7 +320,7 @@ components:
           type: string
           format: uri
         credentials:
-          $ref: '#/components/schemas/ApiKey'
+          $ref: 'BaseComponents.yaml#/components/schemas/ApiKey'
       required:
         - credentials
 
@@ -540,30 +376,12 @@ components:
           externalDocs:
             url: https://firebase.google.com/docs/reference/android/com/google/firebase/FirebaseOptions
 
-
-    ApiKey:
-      description: |
-        Credentials for the App for interacting with the backends
-      type: object
-      readOnly: true
-      properties:
-        apiId:
-          type: string
-          readOnly: true
-        apiKey:
-          type: string
-          readOnly: true
-      required:
-        - apiId
-        - apiKey
-
-
     DataBulk:
       type: object
       description: A bulk of observation data containing a unique id, the API Key of the participant and the array of observation data
       properties:
         bulkId:
-          $ref: '#/components/schemas/Id'
+          $ref: 'BaseComponents.yaml#/components/schemas/Id'
         dataPoints:
           type: array
           items:
@@ -576,7 +394,7 @@ components:
       type: object
       properties:
         dataId:
-          $ref: '#/components/schemas/Id'
+          $ref: 'BaseComponents.yaml#/components/schemas/Id'
         observationId:
           type: string
         observationType:
@@ -603,9 +421,6 @@ components:
       required:
         - code
         - state
-
-    Id:
-      type: string
 
     Error:
       description: Generic Error
@@ -636,13 +451,6 @@ components:
       description: The registration token of a participant
 
   responses:
-    StudyInfoResponse:
-      description: The Study Info
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Study'
-
     NoSuchRegistrationToken:
       description: Invalid/Unknown Registration Token
     RegistrationTokenExpired:
@@ -651,10 +459,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-    UnauthorizedApiKey:
-      description: |
-        **Authentication Required**
-        Login is performed via `basic-auth` using `apiId` as username and `apiKey` as password.
     RegistrationNotPossible:
       description: |
         Registration could not be completed:

--- a/src/main/resources/openapi/ObservationExecutionAPI.yaml
+++ b/src/main/resources/openapi/ObservationExecutionAPI.yaml
@@ -1,0 +1,104 @@
+openapi: 3.0.3
+info:
+  title: ObservationExecutionAPI
+  description: Provides data or redirects for given observations
+  version: 1.0.0
+
+servers:
+  - url: /api/v1/execution
+
+tags:
+  - name: Execution
+
+paths:
+  /observation/{observation-id}/:
+    get:
+      operationId: execObservation
+      description: Executes provided observation and schedule, like redirecting to a lime survey
+      tags:
+        - Execution
+      parameters:
+        - $ref: '#/components/parameters/ObservationId'
+        - $ref: '#/components/parameters/ScheduleStart'
+        - $ref: '#/components/parameters/ScheduleEnd'
+        - $ref: '#/components/parameters/Redirect'
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No Content
+        '302':
+          description: Found
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '409':
+          description: Observation with schedule already done
+
+  /callback:
+    get:
+      operationId: callback
+      description: Callback route used by a service to redirect back to the initial application
+      tags:
+        - Execution
+      responses:
+        '200':
+          description: OK
+          content:
+            text/html:
+              schema:
+                type: string
+        '302':
+          description: Found
+        '403':
+          description: Forbidden
+
+  /callback/end.htm:
+    get:
+      operationId: callbackEndHtm
+      description: Backward compatible callback route for legacy applications
+      tags:
+        - Execution
+      responses:
+        '200':
+          description: OK
+          content:
+            text/html:
+              schema:
+                type: string
+        '302':
+          description: Found
+        '403':
+          description: Forbidden
+
+components:
+  parameters:
+    ObservationId:
+      name: observation-id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The required observation id of the observation
+    ScheduleStart:
+      name: schedule-start
+      in: query
+      required: true
+      schema:
+        type: string
+      description: The start date and time of the schedule
+    ScheduleEnd:
+      name: schedule-end
+      in: query
+      required: true
+      schema:
+        type: string
+      description: The end date and time of the schedule
+    Redirect:
+      name: redirect
+      in: query
+      required: false
+      schema:
+        type: string
+      description: The redirect URL (base URI) to redirect back to

--- a/src/main/resources/openapi/ParticipantPortalAPI.yaml
+++ b/src/main/resources/openapi/ParticipantPortalAPI.yaml
@@ -1,0 +1,125 @@
+openapi: 3.0.3
+info:
+  title: Participant Portal API
+  description: Participant Portal API
+  version: 1.0.0
+servers:
+  - url: /participant-portal/api/v1
+
+tags:
+  - name: Authorization
+    description: |
+      Login endpoints to authorize the user.
+  - name: Configuration
+    description: |
+      Accessing data like study configurations, observation data and schedules
+
+paths:
+  /login/{more-study-id}/{more-user-data-reference}:
+    post:
+      operationId: participantLogin
+      description: Login the participant with the login code
+      tags:
+        - Authorization
+      parameters:
+        - $ref: '#/components/parameters/StudyId'
+        - $ref: '#/components/parameters/UserDataReference'
+        - $ref: '#/components/parameters/LoginCode'
+      responses:
+        '204':
+          description: Success
+        '401':
+          description: 'Unauthorized'
+  /logout:
+    post:
+      operationId: participantLogout
+      description: Logout the current participant
+      tags:
+        - Authorization
+      responses:
+        '204':
+          description: Successfully logged out
+        '403':
+          description: Forbidden
+
+  /consent:
+    get:
+      operationId: retrieveConsentData
+      description: Query study information to create consent
+      tags:
+        - Authorization
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: 'BaseComponents.yaml#/components/schemas/Study'
+        '403':
+          description: 'Forbidden'
+        '404':
+          description: 'Data not found'
+        '409':
+          description: 'Consent was already accepted'
+
+    post:
+      operationId: acceptConsent
+      description: Sends the accepted user consent and returns with a redirect
+      tags:
+        - Authorization
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'BaseComponents.yaml#/components/schemas/StudyConsent'
+      responses:
+        '204':
+          description: OK
+        '403':
+          description: 'Forbidden'
+        '409':
+          description: 'Consent was already accepted'
+
+  /config/study:
+    get:
+      operationId: getStudyConfiguration
+      description: Loads study-, observation and schedule information
+      tags:
+        - Configuration
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: 'BaseComponents.yaml#/components/schemas/Study'
+        '403':
+          description: 'Forbidden'
+        '404':
+          description: 'Study not found'
+
+components:
+  parameters:
+    LoginCode:
+      name: more-login-code
+      in: header
+      required: true
+      schema:
+        type: string
+      description: The login token encrypted in base64
+    StudyId:
+      name: more-study-id
+      in: path
+      description: The unique identifier of the study
+      required: true
+      schema:
+        type: integer
+        format: int64
+    UserDataReference:
+      name: more-user-data-reference
+      in: path
+      description: A unique identifier for an action or dataquey
+      schema:
+        type: string
+      required: true

--- a/src/test/java/io/redlink/more/data/controller/ObservationExecutionControllerTest.java
+++ b/src/test/java/io/redlink/more/data/controller/ObservationExecutionControllerTest.java
@@ -1,0 +1,298 @@
+package io.redlink.more.data.controller;
+
+import io.redlink.more.data.configuration.AuthenticationFacade;
+import io.redlink.more.data.model.ActiveObservation;
+import io.redlink.more.data.model.CompletedData;
+import io.redlink.more.data.model.GatewayUserDetails;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.service.ObservationExecutionService;
+import io.redlink.more.data.service.StudyService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ObservationExecutionControllerTest {
+
+    @Mock
+    private AuthenticationFacade authenticationFacade;
+
+    @Mock
+    private StudyService studyService;
+
+    @Mock
+    private ObservationExecutionService observationExecutionService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    private ObservationExecutionController observationExecutionController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        observationExecutionController = new ObservationExecutionController(authenticationFacade, studyService, observationExecutionService);
+        mockMvc = MockMvcBuilders.standaloneSetup(observationExecutionController)
+                .setControllerAdvice(new GlobalControllerExceptionHandler())
+                .build();
+        ServletRequestAttributes attributes = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(attributes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void testExecObservationSuccess() {
+        String observationId = "1";
+        Instant start = Instant.now();
+        Instant end = start.plusSeconds(3600);
+        String redirect = "http://redirect.com";
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        GatewayUserDetails userDetails = new GatewayUserDetails("user", "pass", Set.of(), routingInfo);
+        Authentication authentication = mock(Authentication.class);
+
+        when(authenticationFacade.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        when(observationExecutionService.executeObservation(observationId, start, end, routingInfo, redirect)).thenReturn(Optional.of(URI.create("http://limesurvey.com")));
+
+        ResponseEntity<Void> response = observationExecutionController.execObservation(observationId, start.toString(), end.toString(), redirect);
+
+        assertEquals(HttpStatus.FOUND, response.getStatusCode());
+        assertEquals("http://limesurvey.com", response.getHeaders().getLocation().toString());
+    }
+
+    @Test
+    void testExecObservationAlreadyReportedRedirect() {
+        String observationId = "1";
+        Instant start = Instant.now();
+        Instant end = start.plusSeconds(3600);
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        GatewayUserDetails userDetails = new GatewayUserDetails("user", "pass", Set.of(), routingInfo);
+        Authentication authentication = mock(Authentication.class);
+        ActiveObservation activeObservation = new ActiveObservation(observationId, start, end);
+        CompletedData completedData = CompletedData.fromActiveObservation(activeObservation);
+
+        when(authenticationFacade.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+
+        when(observationExecutionService.executeObservation(eq(observationId), any(), any(), eq(routingInfo), any()))
+                .thenReturn(Optional.of(URI.create("http://redirect.com?status=200")));
+
+        ResponseEntity<Void> response = observationExecutionController.execObservation(observationId, start.toString(), end.toString(), null);
+
+        assertEquals(HttpStatus.FOUND, response.getStatusCode());
+        assertEquals("http://redirect.com?status=200", response.getHeaders().getLocation().toString());
+    }
+
+    @Test
+    void testExecObservationAlreadyReportedDefaultRedirect() {
+        String observationId = "1";
+        Instant start = Instant.now();
+        Instant end = start.plusSeconds(3600);
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        GatewayUserDetails userDetails = new GatewayUserDetails("user", "pass", Set.of(), routingInfo);
+        Authentication authentication = mock(Authentication.class);
+        ActiveObservation activeObservation = new ActiveObservation(observationId, start, end);
+        CompletedData completedData = CompletedData.fromActiveObservation(activeObservation);
+
+        when(authenticationFacade.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+
+        when(observationExecutionService.executeObservation(eq(observationId), any(), any(), eq(routingInfo), any()))
+                .thenReturn(Optional.empty());
+        when(request.getContextPath()).thenReturn("");
+
+        ResponseEntity<Void> response = observationExecutionController.execObservation(observationId, start.toString(), end.toString(), null);
+
+        assertEquals(HttpStatus.FOUND, response.getStatusCode());
+        String location = response.getHeaders().getLocation().toString();
+        assertTrue(location.endsWith("/api/v1/execution/callback/end.htm?status=409"));
+    }
+
+    @Test
+    void testExecObservationDateOnly() throws Exception {
+        String observationId = "1";
+        String dateOnly = "2026-04-14";
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        GatewayUserDetails userDetails = new GatewayUserDetails("user", "pass", Set.of(), routingInfo);
+        Authentication authentication = mock(Authentication.class);
+
+        when(authenticationFacade.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        when(observationExecutionService.executeObservation(eq(observationId), any(), any(), eq(routingInfo), any())).thenReturn(Optional.of(URI.create("http://limesurvey.com")));
+
+        org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder requestBuilder = org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/api/v1/execution/observation/{observation-id}/", observationId)
+                .param("schedule-start", dateOnly)
+                .param("schedule-end", dateOnly);
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().is3xxRedirection());
+    }
+
+    @Test
+    void testExecObservationInvalidDate() throws Exception {
+        String observationId = "1";
+        String invalidDate = "not-a-date";
+
+        org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder requestBuilder = org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/api/v1/execution/observation/{observation-id}/", observationId)
+                .param("schedule-start", invalidDate)
+                .param("schedule-end", invalidDate);
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().is3xxRedirection())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern("**/end.htm?status=403"));
+    }
+
+    @Test
+    void testExecObservationForbidden() throws Exception {
+        String observationId = "1";
+        Instant start = Instant.now();
+        Instant end = start.plusSeconds(3600);
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        GatewayUserDetails userDetails = new GatewayUserDetails("user", "pass", Set.of(), routingInfo);
+        Authentication authentication = mock(Authentication.class);
+
+        when(authenticationFacade.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        when(observationExecutionService.executeObservation(eq(observationId), any(), any(), eq(routingInfo), any())).thenThrow(new io.redlink.more.data.exception.ForbiddenException("Forbidden test"));
+
+        org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder requestBuilder = org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/api/v1/execution/observation/{observation-id}/", observationId)
+                .param("schedule-start", start.toString())
+                .param("schedule-end", end.toString());
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().is3xxRedirection())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern("**/end.htm?status=403"));
+    }
+
+    @Test
+    void testCallbackIllegalArgument() throws Exception {
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        GatewayUserDetails userDetails = new GatewayUserDetails("user", "pass", Set.of(), routingInfo);
+        Authentication authentication = mock(Authentication.class);
+        ActiveObservation activeObservation = new ActiveObservation("1", Instant.now(), Instant.now().plusSeconds(3600));
+
+        when(authenticationFacade.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+
+        when(observationExecutionService.processCallback(any())).thenThrow(new IllegalArgumentException("Missing params"));
+
+        org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder requestBuilder = org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/api/v1/execution/callback");
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().is3xxRedirection())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern("**/end.htm?status=403"));
+    }
+
+    @Test
+    void testCallbackProcessFailure() throws Exception {
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        GatewayUserDetails userDetails = new GatewayUserDetails("user", "pass", Set.of(), routingInfo);
+        Authentication authentication = mock(Authentication.class);
+        ActiveObservation activeObservation = new ActiveObservation("1", Instant.now(), Instant.now().plusSeconds(3600));
+
+        when(authenticationFacade.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+
+        when(observationExecutionService.processCallback(any())).thenReturn(Optional.empty());
+
+        org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder requestBuilder = org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/api/v1/execution/callback")
+                .requestAttr(org.springframework.web.servlet.HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, new HashMap<>());
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().is3xxRedirection())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern("**/end.htm?status=200"));
+    }
+
+    @Test
+    void testCallbackRedirectsToEndHtm() {
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        GatewayUserDetails userDetails = new GatewayUserDetails("user", "pass", Set.of(), routingInfo);
+        Authentication authentication = mock(Authentication.class);
+
+        when(authenticationFacade.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        lenient().when(request.getParameterMap()).thenReturn(new HashMap<>(Map.of(
+                "savedId", new String[]{"123"},
+                "observationid", new String[]{"1"}
+        )));
+        lenient().when(request.getRequestURI()).thenReturn("/api/v1/execution/callback");
+        lenient().when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/api/v1/execution/callback"));
+        lenient().when(request.getContextPath()).thenReturn("");
+
+        lenient().when(request.getAttribute(org.springframework.web.servlet.HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(new HashMap<>());
+        lenient().when(observationExecutionService.processCallback(any())).thenReturn(Optional.of(URI.create("http://redirect.com/end.htm")));
+
+        ResponseEntity<String> response = observationExecutionController.callback();
+
+        assertEquals(HttpStatus.FOUND, response.getStatusCode());
+        String location = response.getHeaders().getLocation().toString();
+        assertTrue(location.contains("end.htm"));
+        assertTrue(location.contains("savedid=123"));
+        assertTrue(location.contains("status=200"));
+    }
+
+    @Test
+    void testCallbackEndHtmSuccess() {
+        ResponseEntity<String> response = observationExecutionController.callbackEndHtm();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().contains("<html>"));
+    }
+
+    @Test
+    void testCallbackFallbackSuccess() {
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+
+        // No authentication
+        lenient().when(authenticationFacade.getAuthentication()).thenReturn(null);
+
+        // Parameters provided
+        Map<String, String[]> paramMap = new HashMap<>();
+        paramMap.put("studyid", new String[]{"1"});
+        paramMap.put("observationid", new String[]{"101"});
+        paramMap.put("token", new String[]{"token123"});
+        lenient().when(request.getParameterMap()).thenReturn(paramMap);
+
+        lenient().when(request.getRequestURI()).thenReturn("/api/v1/execution/callback");
+        lenient().when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/api/v1/execution/callback"));
+        lenient().when(request.getContextPath()).thenReturn("");
+        lenient().when(request.getAttribute(org.springframework.web.servlet.HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(new HashMap<>());
+
+        lenient().when(observationExecutionService.processCallback(any())).thenReturn(Optional.of(URI.create("http://redirect.com")));
+
+        ResponseEntity<String> response = observationExecutionController.callback();
+
+        assertEquals(HttpStatus.FOUND, response.getStatusCode());
+        String location = response.getHeaders().getLocation().toString();
+        assertTrue(location.contains("status=200"));
+        verify(observationExecutionService).processCallback(any());
+    }
+}

--- a/src/test/java/io/redlink/more/data/controller/participantportal/ParticipantPortalControllerTest.java
+++ b/src/test/java/io/redlink/more/data/controller/participantportal/ParticipantPortalControllerTest.java
@@ -1,0 +1,496 @@
+package io.redlink.more.data.controller.participantportal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.redlink.more.data.api.participant.v1.model.StudyConsentDTO;
+import io.redlink.more.data.configuration.SchedulerProperties;
+import io.redlink.more.data.configuration.SecurityConfig;
+import io.redlink.more.data.controller.GlobalControllerExceptionHandler;
+import io.redlink.more.data.model.Contact;
+import io.redlink.more.data.model.DataHealth;
+import io.redlink.more.data.model.Observation;
+import io.redlink.more.data.model.ObservationDataState;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.model.SimpleParticipant;
+import io.redlink.more.data.model.Study;
+import io.redlink.more.data.model.StudyParticipantUserDetails;
+import io.redlink.more.data.model.scheduler.Duration;
+import io.redlink.more.data.model.scheduler.Event;
+import io.redlink.more.data.model.scheduler.RelativeDate;
+import io.redlink.more.data.model.scheduler.RelativeEvent;
+import io.redlink.more.data.model.scheduler.RelativeRecurrenceRule;
+import io.redlink.more.data.service.ApplicationAccessService;
+import io.redlink.more.data.service.DataHealthService;
+import io.redlink.more.data.service.GatewayUserDetailService;
+import io.redlink.more.data.service.LoginTokenService;
+import io.redlink.more.data.service.ObservationExecutionService;
+import io.redlink.more.data.service.RegistrationService;
+import io.redlink.more.data.service.StudyService;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest({ParticipantPortalController.class, GlobalControllerExceptionHandler.class})
+@Import(SecurityConfig.class)
+@AutoConfigureMockMvc
+class ParticipantPortalControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ApplicationAccessService applicationAccessService;
+
+    @MockitoBean
+    private StudyService studyService;
+
+    @MockitoBean
+    private LoginTokenService loginTokenService;
+
+    @MockitoBean
+    private RegistrationService registrationService;
+
+    @MockitoBean
+    private GatewayUserDetailService gatewayUserDetailService;
+
+    @MockitoBean
+    private PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    private DataHealthService dataHealthService;
+
+    @MockitoBean
+    private ObservationExecutionService observationExecutionService;
+
+    @MockitoBean
+    private SchedulerProperties schedulerProperties;
+
+    @Test
+    void testParticipantLoginSetsSession() throws Exception {
+        Long studyId = 1L;
+        String userDataRef = "user-ref";
+        String loginCode = "login-code";
+        String encodedCode = Base64.getEncoder().encodeToString(loginCode.getBytes(StandardCharsets.UTF_8));
+        RoutingInfo routingInfo = new RoutingInfo(studyId, 1, OptionalInt.empty(), Set.of(), true, true);
+
+        when(applicationAccessService.validateLogin(studyId, userDataRef, loginCode))
+                .thenReturn(Optional.of(routingInfo));
+        when(studyService.getStudyState(studyId)).thenReturn(Optional.of("active"));
+
+        MvcResult result = mockMvc.perform(post("/participant-portal/api/v1/login/{studyId}/{userDataRef}", studyId, userDataRef)
+                        .with(csrf())
+                        .header("more-login-code", encodedCode))
+                .andExpect(status().isNoContent())
+                .andReturn();
+
+        MockHttpSession session = (MockHttpSession) result.getRequest().getSession(false);
+        assertNotNull(session);
+        assertNotNull(session.getAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY));
+    }
+
+    @Test
+    void testParticipantLoginInvalidBase64() throws Exception {
+        Long studyId = 2L;
+        String userDataRef = "user-ref";
+        String invalidEncodedCode = "!!! not base64 !!!";
+
+        mockMvc.perform(post("/participant-portal/api/v1/login/{studyId}/{userDataRef}", studyId, userDataRef)
+                        .with(csrf())
+                        .header("more-login-code", invalidEncodedCode))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testParticipantLoginInvalidCredentials() throws Exception {
+        Long studyId = 3L;
+        String userDataRef = "user-ref";
+        String loginCode = "wrong-code";
+        String encodedCode = Base64.getEncoder().encodeToString(loginCode.getBytes(StandardCharsets.UTF_8));
+
+        when(applicationAccessService.validateLogin(studyId, userDataRef, loginCode))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(post("/participant-portal/api/v1/login/{studyId}/{userDataRef}", studyId, userDataRef)
+                        .with(csrf())
+                        .header("more-login-code", encodedCode))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testParticipantLogout() throws Exception {
+        long studyId = 4L;
+        int participantId = 1;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, "some-context");
+
+        mockMvc.perform(post("/participant-portal/api/v1/logout")
+                        .with(user(userDetails))
+                        .session(session)
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+
+        assertTrue(session.isInvalid());
+    }
+
+    @Test
+    void testParticipantLogoutNoSession() throws Exception {
+        long studyId = 5L;
+        int participantId = 2;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+
+        mockMvc.perform(post("/participant-portal/api/v1/logout")
+                        .with(user(userDetails))
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void testParticipantLogoutUnauthenticated() throws Exception {
+        mockMvc.perform(post("/participant-portal/api/v1/logout")
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testAcceptConsentSuccess() throws Exception {
+        long studyId = 6L;
+        int participantId = 3;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+
+        StudyConsentDTO consentDTO = new StudyConsentDTO();
+        consentDTO.setConsent(true);
+        consentDTO.setDeviceId("MODEL#SERIAL");
+
+        when(applicationAccessService.hasConsent(routingInfo)).thenReturn(false);
+        when(studyService.getRoutingInfo(studyId, participantId)).thenReturn(Optional.of(routingInfo));
+        when(studyService.getStudyState(studyId)).thenReturn(Optional.of("active"));
+
+        mockMvc.perform(post("/participant-portal/api/v1/consent")
+                        .with(csrf())
+                        .with(user(userDetails))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(consentDTO)))
+                .andExpect(status().isNoContent());
+
+        verify(applicationAccessService).validateAndStoreConsent(eq(routingInfo), any());
+    }
+
+    @Test
+    void testAcceptConsentAlreadyReported() throws Exception {
+        long studyId = 7L;
+        int participantId = 4;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+
+        when(applicationAccessService.hasConsent(routingInfo)).thenReturn(true);
+        when(studyService.getRoutingInfo(studyId, participantId)).thenReturn(Optional.of(routingInfo));
+        when(studyService.getStudyState(studyId)).thenReturn(Optional.of("active"));
+
+        mockMvc.perform(post("/participant-portal/api/v1/consent")
+                        .with(csrf())
+                        .with(user(userDetails))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void testRetrieveConsentDataSuccess() throws Exception {
+        long studyId = 8L;
+        int participantId = 5;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+        Study study = new Study(studyId, "Title", true, "Info", "Finish", "active", "Consent",
+                new Contact("Inst", "Person", "email", "phone"),
+                LocalDate.now(), LocalDate.now(), LocalDate.now().plusDays(10),
+                Collections.emptyList(), Instant.now(), Instant.now(),
+                new SimpleParticipant(participantId, "alias", Instant.now(), Instant.now().plus(10, ChronoUnit.DAYS)));
+
+        when(studyService.getRoutingInfo(studyId, participantId)).thenReturn(Optional.of(routingInfo));
+        when(applicationAccessService.hasConsent(routingInfo)).thenReturn(false);
+        when(studyService.getStudyState(studyId)).thenReturn(Optional.of("active"));
+        when(studyService.getStudy(routingInfo)).thenReturn(Optional.of(Pair.of(study, Collections.emptyList())));
+
+        mockMvc.perform(get("/participant-portal/api/v1/consent")
+                        .with(user(userDetails)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testRetrieveConsentDataUnauthorized() throws Exception {
+        long studyId = 9L;
+        int participantId = 6;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+
+        when(studyService.getRoutingInfo(studyId, participantId)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/participant-portal/api/v1/consent")
+                        .with(user(userDetails)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testRetrieveConsentDataAlreadyReported() throws Exception {
+        long studyId = 10L;
+        int participantId = 7;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+
+        when(studyService.getRoutingInfo(studyId, participantId)).thenReturn(Optional.of(routingInfo));
+        when(studyService.getStudyState(studyId)).thenReturn(Optional.of("active"));
+        when(applicationAccessService.hasConsent(routingInfo)).thenReturn(true);
+
+        mockMvc.perform(get("/participant-portal/api/v1/consent")
+                        .with(user(userDetails)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void testRetrieveConsentDataStudyNotFound() throws Exception {
+        long studyId = 11L;
+        int participantId = 8;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+
+        when(studyService.getRoutingInfo(studyId, participantId)).thenReturn(Optional.of(routingInfo));
+        when(applicationAccessService.hasConsent(routingInfo)).thenReturn(false);
+        when(studyService.getStudyState(studyId)).thenReturn(Optional.of("active"));
+        when(studyService.getStudy(routingInfo)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/participant-portal/api/v1/consent")
+                        .with(user(userDetails)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser
+    void testAcceptConsentWithMockUserFails() throws Exception {
+        // This should fail because the principal is not RoutingInfoUserDetails
+        // It's now handled by the ExceptionHandler and returns 500
+        mockMvc.perform(post("/participant-portal/api/v1/consent")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testGetStudyConfigurationSuccess() throws Exception {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.HOURS);
+        long studyId = 12L;
+        var studyStart = LocalDate.now().minusDays(1);
+        var studyEnd = LocalDate.now().plusDays(14);
+
+
+        int participantId = 9;
+        Instant participantStart = now.minus(26, ChronoUnit.HOURS);
+        Instant participantEnd = now.plus(10, ChronoUnit.DAYS);
+
+        Instant absStart = now.minus(1, ChronoUnit.HOURS);
+        Instant absEnd = now.plus(3, ChronoUnit.HOURS);
+
+        ZoneId zone = ZoneId.systemDefault();
+
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+        var observation1 = new Observation(1, null, "observation 1", "type", "participant info",
+                null,
+                new Event().setDateStart(absStart).setDateEnd(absEnd),
+                null, null, //created, modified
+                false, false, false, Set.of());
+        var observation2 = new Observation(2, null, "observation 2", "type", "participant info",
+                null,
+                new RelativeEvent()
+                        .setDtstart(new RelativeDate()
+                                .setTime(LocalTime.from(absStart.atZone(zone)))
+                                .setOffset(new Duration().setValue(1).setUnit(Duration.Unit.DAY)))
+                        .setDtend(new RelativeDate()
+                                .setTime(LocalTime.from(absEnd.atZone(zone)))
+                                .setOffset(new Duration().setValue(1).setUnit(Duration.Unit.DAY)))
+                        .setRrrule(new RelativeRecurrenceRule()
+                                .setFrequency(new Duration().setValue(1).setUnit(Duration.Unit.DAY))
+                                .setEndAfter(new Duration().setValue(8).setUnit(Duration.Unit.DAY))),
+                now.minus(1, ChronoUnit.DAYS),
+                now.minus(1, ChronoUnit.DAYS),
+                false, false, false, Set.of());
+        Study study = new Study(studyId, "Title", true, "Info", "Finish", "active", "Consent",
+                new Contact("Inst", "Person", "email", "phone"),
+                studyStart, studyStart, studyEnd,
+                List.of(observation1, observation2), Instant.now(), Instant.now(),
+                new SimpleParticipant(participantId, "alias", participantStart, participantEnd));
+
+        when(studyService.getRoutingInfo(studyId, participantId)).thenReturn(Optional.of(routingInfo));
+        when(studyService.getStudyState(studyId)).thenReturn(Optional.of("active"));
+        when(studyService.getStudy(routingInfo)).thenReturn(Optional.of(Pair.of(study, Collections.emptyList())));
+        when(dataHealthService.checkDataHealth(studyId, participantId, observation1.observationId(), absStart)).thenReturn(
+                new DataHealth(true, ObservationDataState.COMPLETE)
+        );
+        when(dataHealthService.checkDataHealth(studyId, participantId, observation2.observationId(), absStart)).thenReturn(
+                new DataHealth(false, ObservationDataState.COMPLETE)
+        );
+        //when(dataHealthService.checkDataHealth(eq(studyId), eq(participantId), anyInt(), any())).thenReturn(
+        //        new DataHealth(true, ObservationDataState.MISSING)
+        //);
+
+        mockMvc.perform(get("/participant-portal/api/v1/config/study")
+                        .with(user(userDetails)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active").value(true))
+                .andExpect(jsonPath("$.studyState").value("active"))
+
+                .andExpect(jsonPath("$.participant.id").doesNotExist())
+                .andExpect(jsonPath("$.participant.alias").value("alias"))
+
+                .andExpect(jsonPath("$.studyTitle").value("Title"))
+                .andExpect(jsonPath("$.participantInfo").value("Info"))
+                .andExpect(jsonPath("$.consentInfo").value("Consent"))
+                .andExpect(jsonPath("$.finishText").value("Finish"))
+
+                .andExpect(jsonPath("$.contact.institute").value("Inst"))
+                .andExpect(jsonPath("$.contact.person").value("Person"))
+                .andExpect(jsonPath("$.contact.email").value("email"))
+                .andExpect(jsonPath("$.contact.phoneNumber").value("phone"))
+
+                // Study dates - using variables from the test
+                .andExpect(jsonPath("$.start").value(studyStart.toString()))
+                .andExpect(jsonPath("$.end").value(studyEnd.toString()))
+
+                // === Observation 1 ===
+                .andExpect(jsonPath("$.observations[0].observationId").value("1"))
+                .andExpect(jsonPath("$.observations[0].observationType").value("type"))
+                .andExpect(jsonPath("$.observations[0].observationTitle").value("observation 1"))
+                .andExpect(jsonPath("$.observations[0].participantInfo").value("participant info"))
+                .andExpect(jsonPath("$.observations[0].required").value(true))
+                .andExpect(jsonPath("$.observations[0].hidden").value(false))
+                .andExpect(jsonPath("$.observations[0].noSchedule").value(false))
+                .andExpect(jsonPath("$.observations[0].reminder").value(false))
+                .andExpect(jsonPath("$.observations[0].version").doesNotExist())
+                .andExpect(jsonPath("$.observations[0].configuration").doesNotExist())
+
+                // Schedule for observation 1 (single absolute event)
+                .andExpect(jsonPath("$.observations[0].schedule[0].start").value(absStart.toString()))
+                .andExpect(jsonPath("$.observations[0].schedule[0].end").value(absEnd.toString()))
+                .andExpect(jsonPath("$.observations[0].schedule[0].dataHealth").value("completed"))
+
+                // === Observation 2 ===
+                .andExpect(jsonPath("$.observations[1].observationId").value("2"))
+                .andExpect(jsonPath("$.observations[1].observationType").value("type"))
+                .andExpect(jsonPath("$.observations[1].observationTitle").value("observation 2"))
+                .andExpect(jsonPath("$.observations[1].participantInfo").value("participant info"))
+                .andExpect(jsonPath("$.observations[1].required").value(true))
+                .andExpect(jsonPath("$.observations[1].hidden").value(false))
+                .andExpect(jsonPath("$.observations[1].noSchedule").value(false))
+                .andExpect(jsonPath("$.observations[1].reminder").value(false))
+                .andExpect(jsonPath("$.observations[1].version").isNumber())
+                .andExpect(jsonPath("$.observations[1].configuration").doesNotExist())
+
+                // Schedule entries for observation 2
+                .andExpect(jsonPath("$.observations[1].schedule.length()").value(8))
+
+                // First schedule entry (should be completed according to the mocked dataHealth)
+                .andExpect(jsonPath("$.observations[1].schedule[0].start").value(absStart.minus(1, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[0].end").value(absEnd.minus(1, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[0].dataHealth").doesNotExist())
+
+                // The rest of the recurring entries (dataHealth is null or "invalid" as in the example JSON)
+                .andExpect(jsonPath("$.observations[1].schedule[1].start").value(absStart.toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[1].end").value(absEnd.toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[1].dataHealth").value("invalid"))
+                .andExpect(jsonPath("$.observations[1].schedule[2].start").value(absStart.plus(1, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[2].end").value(absEnd.plus(1, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[2].dataHealth").doesNotExist())
+                .andExpect(jsonPath("$.observations[1].schedule[3].start").value(absStart.plus(2, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[3].end").value(absEnd.plus(2, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[3].dataHealth").doesNotExist())
+                .andExpect(jsonPath("$.observations[1].schedule[4].start").value(absStart.plus(3, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[4].end").value(absEnd.plus(3, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[4].dataHealth").doesNotExist())
+                .andExpect(jsonPath("$.observations[1].schedule[5].start").value(absStart.plus(4, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[5].end").value(absEnd.plus(4, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[5].dataHealth").doesNotExist())
+                .andExpect(jsonPath("$.observations[1].schedule[6].start").value(absStart.plus(5, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[6].end").value(absEnd.plus(5, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[6].dataHealth").doesNotExist())
+                .andExpect(jsonPath("$.observations[1].schedule[7].start").value(absStart.plus(6, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[7].end").value(absEnd.plus(6, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[7].dataHealth").doesNotExist());
+    }
+
+    @Test
+    void testGetStudyConfigurationUnauthorized() throws Exception {
+        long studyId = 13L;
+        int participantId = 10;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+
+        when(studyService.getRoutingInfo(studyId, participantId)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/participant-portal/api/v1/config/study")
+                        .with(user(userDetails)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testGetStudyConfigurationNotFound() throws Exception {
+        long studyId = 14L;
+        int participantId = 11;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+
+        when(studyService.getRoutingInfo(studyId, participantId)).thenReturn(Optional.of(routingInfo));
+        when(studyService.getStudyState(studyId)).thenReturn(Optional.of("active"));
+        when(studyService.getStudy(routingInfo)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/participant-portal/api/v1/config/study")
+                        .with(user(userDetails)))
+                .andExpect(status().isNotFound());
+    }
+
+}

--- a/src/test/java/io/redlink/more/data/service/ApplicationAccessServiceTest.java
+++ b/src/test/java/io/redlink/more/data/service/ApplicationAccessServiceTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.service;
+
+import io.redlink.more.data.event.ParticipantUpdateAction;
+import io.redlink.more.data.event.ParticipantUpdateEvent;
+import io.redlink.more.data.model.ParticipantApplication;
+import io.redlink.more.data.model.ParticipantConsent;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.repository.ParticipantApplicationRepository;
+import io.redlink.more.data.repository.StudyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationAccessServiceTest {
+
+    @Mock
+    private LoginTokenService loginTokenService;
+
+    @Mock
+    private ParticipantApplicationRepository participantApplicationRepository;
+
+    @Mock
+    private StudyRepository studyRepository;
+
+    private ApplicationAccessService applicationAccessService;
+
+    @BeforeEach
+    void setUp() {
+        applicationAccessService = new ApplicationAccessService(loginTokenService, participantApplicationRepository, studyRepository);
+    }
+
+
+    @Test
+    void testValidateLoginSuccess() {
+        Long studyId = 1L;
+        String userDataRef = "user-ref";
+        String loginToken = "token";
+        ParticipantApplication application = new ParticipantApplication();
+        RoutingInfo routingInfo = new RoutingInfo(studyId, 1, OptionalInt.empty(), Set.of(), true, true);
+
+        when(participantApplicationRepository.findByUserDataReference(studyId, userDataRef)).thenReturn(Optional.of(application));
+        when(loginTokenService.validateToken(loginToken, application)).thenReturn(Optional.of(routingInfo));
+
+        Optional<RoutingInfo> result = applicationAccessService.validateLogin(studyId, userDataRef, loginToken);
+
+        assertTrue(result.isPresent());
+        assertEquals(routingInfo, result.get());
+    }
+
+    @Test
+    void testValidateLoginApplicationNotFound() {
+        Long studyId = 1L;
+        String userDataRef = "user-ref";
+        String loginToken = "token";
+
+        when(participantApplicationRepository.findByUserDataReference(studyId, userDataRef)).thenReturn(Optional.empty());
+
+        Optional<RoutingInfo> result = applicationAccessService.validateLogin(studyId, userDataRef, loginToken);
+
+        assertFalse(result.isPresent());
+        verifyNoInteractions(loginTokenService);
+    }
+
+    @Test
+    void testHasConsentAccepted() {
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        ParticipantConsent consent = new ParticipantConsent(true, "device", "md5", null, null);
+
+        when(studyRepository.getConsent(1L, 1)).thenReturn(Optional.of(consent));
+
+        assertTrue(applicationAccessService.hasConsent(routingInfo));
+    }
+
+    @Test
+    void testHasConsentNotAccepted() {
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        ParticipantConsent consent = new ParticipantConsent(false, "device", "md5", null, null);
+
+        when(studyRepository.getConsent(1L, 1)).thenReturn(Optional.of(consent));
+
+        assertFalse(applicationAccessService.hasConsent(routingInfo));
+    }
+
+    @Test
+    void testHasConsentNotFound() {
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+
+        when(studyRepository.getConsent(1L, 1)).thenReturn(Optional.empty());
+
+        assertFalse(applicationAccessService.hasConsent(routingInfo));
+    }
+
+    @Test
+    void testValidateAndStoreConsentSuccess() {
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        ParticipantConsent consent = new ParticipantConsent(true, "device", "md5", null, null);
+
+        applicationAccessService.validateAndStoreConsent(routingInfo, consent);
+
+        verify(studyRepository).storeConsent(1L, 1, consent);
+    }
+
+    @Test
+    void testValidateAndStoreConsentThrowsException() {
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        ParticipantConsent consent = new ParticipantConsent(false, "device", "md5", null, null);
+
+        assertThrows(IllegalStateException.class, () -> applicationAccessService.validateAndStoreConsent(routingInfo, consent));
+        verifyNoInteractions(studyRepository);
+    }
+
+    @Test
+    void testOnApplicationEventDelete() {
+        Long studyId = 1L;
+        Integer participantId = 1;
+        ParticipantUpdateEvent event = new ParticipantUpdateEvent(this, studyId, participantId, ParticipantUpdateAction.DELETE);
+
+        applicationAccessService.onApplicationEvent(event);
+
+        verify(participantApplicationRepository).deleteAllByParticipant(studyId, participantId);
+    }
+}

--- a/src/test/java/io/redlink/more/data/service/LoginTokenServiceTest.java
+++ b/src/test/java/io/redlink/more/data/service/LoginTokenServiceTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.data.service;
+
+import io.redlink.more.data.configuration.LoginTokenProperties;
+import io.redlink.more.data.event.ParticipantUpdateAction;
+import io.redlink.more.data.event.ParticipantUpdateEvent;
+import io.redlink.more.data.model.LoginToken;
+import io.redlink.more.data.model.ParticipantApplication;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.repository.LoginTokenRepository;
+import io.redlink.more.data.repository.StudyRepository;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LoginTokenServiceTest {
+
+    @Mock
+    private LoginTokenRepository loginTokenRepository;
+    @Mock
+    private StudyRepository studyRepository;
+
+    private LoginTokenProperties properties;
+    private LoginTokenService loginTokenService;
+
+    private final String hashAlgorithm = "SHA-256";
+
+    @BeforeEach
+    void setUp() {
+        properties = new LoginTokenProperties();
+        properties.setHashAlgorithm(hashAlgorithm);
+        loginTokenService = new LoginTokenService(loginTokenRepository, properties, studyRepository);
+    }
+
+    @Test
+    void testValidateConfigurationSuccess() {
+        assertDoesNotThrow(() -> properties.validateConfiguration());
+    }
+
+    @Test
+    void testValidateConfigurationInvalidHashAlgorithm() {
+        properties.setHashAlgorithm("INVALID-ALGORITHM");
+        assertThrows(IllegalStateException.class, () -> properties.validateConfiguration());
+    }
+
+    @Test
+    void testValidateTokenSuccess() throws NoSuchAlgorithmException {
+        String code = "test-code";
+        Long studyId = 1L;
+        Integer participantId = 10;
+        String applicationName = "test-app";
+        String hashedCode = hash(code);
+
+        ParticipantApplication application = new ParticipantApplication()
+                .setStudyId(studyId)
+                .setParticipantId(participantId)
+                .setApplication(applicationName);
+
+        LoginToken token = new LoginToken()
+                .setStudyId(studyId)
+                .setParticipantId(participantId)
+                .setApplication(applicationName)
+                .setCode("encrypted-code")
+                .setCodeHash(hashedCode);
+
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, 1, Collections.emptySet(), true, true);
+
+        when(loginTokenRepository.findByCodeHash(hashedCode, application)).thenReturn(Optional.of(token));
+        when(studyRepository.getRoutingInfo(studyId, participantId)).thenReturn(Optional.of(routingInfo));
+
+        Optional<RoutingInfo> validatedToken = loginTokenService.validateToken(code, application);
+
+        assertTrue(validatedToken.isPresent());
+        assertEquals(studyId, validatedToken.get().studyId());
+        assertEquals(participantId, validatedToken.get().participantId());
+    }
+
+    @Test
+    void testValidateTokenNotFound() throws NoSuchAlgorithmException {
+        String code = "test-code";
+        Long studyId = 1L;
+        Integer participantId = 10;
+        String applicationName = "test-app";
+        String hashedCode = hash(code);
+
+        ParticipantApplication application = new ParticipantApplication()
+                .setStudyId(studyId)
+                .setParticipantId(participantId)
+                .setApplication(applicationName);
+
+        when(loginTokenRepository.findByCodeHash(hashedCode, application)).thenReturn(Optional.empty());
+
+        Optional<RoutingInfo> validatedToken = loginTokenService.validateToken(code, application);
+
+        assertFalse(validatedToken.isPresent());
+    }
+
+    @Test
+    void testValidateTokenNullCode() {
+        Long studyId = 1L;
+        Integer participantId = 10;
+        String applicationName = "test-app";
+
+        ParticipantApplication application = new ParticipantApplication()
+                .setStudyId(studyId)
+                .setParticipantId(participantId)
+                .setApplication(applicationName);
+
+        when(loginTokenRepository.findByCodeHash(null, application)).thenReturn(Optional.empty());
+
+        Optional<RoutingInfo> validatedToken = loginTokenService.validateToken(null, application);
+
+        assertFalse(validatedToken.isPresent());
+    }
+
+    @Test
+    void testValidateTokenTokenFoundButNoRoutingInfo() throws NoSuchAlgorithmException {
+        String code = "test-code";
+        Long studyId = 1L;
+        Integer participantId = 10;
+        String applicationName = "test-app";
+        String hashedCode = hash(code);
+
+        ParticipantApplication application = new ParticipantApplication()
+                .setStudyId(studyId)
+                .setParticipantId(participantId)
+                .setApplication(applicationName);
+
+        LoginToken token = new LoginToken()
+                .setStudyId(studyId)
+                .setParticipantId(participantId)
+                .setApplication(applicationName);
+
+        when(loginTokenRepository.findByCodeHash(hashedCode, application)).thenReturn(Optional.of(token));
+        when(studyRepository.getRoutingInfo(studyId, participantId)).thenReturn(Optional.empty());
+
+        Optional<RoutingInfo> validatedToken = loginTokenService.validateToken(code, application);
+
+        assertFalse(validatedToken.isPresent());
+    }
+
+    @Test
+    void testOnApplicationEventDelete() {
+        Long studyId = 1L;
+        Integer participantId = 10;
+        ParticipantUpdateEvent event = new ParticipantUpdateEvent(this, studyId, participantId, ParticipantUpdateAction.DELETE);
+
+        loginTokenService.onApplicationEvent(event);
+
+        verify(loginTokenRepository).deleteLoginTokens(studyId, participantId);
+    }
+
+    private String hash(String input) throws NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance(hashAlgorithm);
+        byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+        return Hex.encodeHexString(hash);
+    }
+}

--- a/src/test/java/io/redlink/more/data/service/ObservationExecutionServiceTest.java
+++ b/src/test/java/io/redlink/more/data/service/ObservationExecutionServiceTest.java
@@ -1,0 +1,194 @@
+package io.redlink.more.data.service;
+
+import io.redlink.more.data.exception.ForbiddenException;
+import io.redlink.more.data.exception.NotFoundException;
+import io.redlink.more.data.model.CallbackResult;
+import io.redlink.more.data.model.Observation;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.model.Study;
+import io.redlink.more.data.model.scheduler.Event;
+import io.redlink.more.data.service.observations.ObservationComponent;
+import io.redlink.more.data.store.observationCallback.ObservationCallbackStore;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ObservationExecutionServiceTest {
+
+    @Mock
+    private StudyService studyService;
+
+    @Mock
+    private ObservationComponent observationComponent;
+
+    @Mock
+    ObservationCallbackStore callbackStore;
+
+    private ObservationExecutionService observationExecutionService;
+
+    @BeforeEach
+    void setUp() {
+        when(observationComponent.getObservationType()).thenReturn("test-type");
+        observationExecutionService = new ObservationExecutionService(studyService, callbackStore, List.of(observationComponent));
+    }
+
+    @Test
+    void testExecuteObservationSuccess() {
+        String observationId = "1";
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        Instant start = now.plus(1, ChronoUnit.HOURS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+
+        Event event = new Event();
+        event.setDateStart(start);
+        event.setDateEnd(end);
+
+        Observation observation = new Observation(1, 1, "Title", "test-type", "Info", null, event, now, now, false, false, false, Set.of());
+        Study study = new Study(1L, "Title", true, "Info", "Finish", "active", "Consent", null, null, null, null, List.of(observation), now, now, null);
+
+        when(studyService.getStudy(routingInfo)).thenReturn(Optional.of(Pair.of(study, Collections.emptyList())));
+        when(observationComponent.produceUrl(any(), any(), any(), any())).thenReturn(Optional.of("http://test.com"));
+
+        String url = observationExecutionService.executeObservation(observationId, start, end, routingInfo, null).map(URI::toString).orElse(null);
+
+        assertEquals("http://test.com", url);
+    }
+
+    @Test
+    void testExecuteObservationPreviewSuccess() {
+        String observationId = "1";
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        Instant start = now.plus(1, ChronoUnit.HOURS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+
+        Event event = new Event();
+        event.setDateStart(start);
+        event.setDateEnd(end);
+
+        Observation observation = new Observation(1, 1, "Title", "test-type", "Info", null, event, now, now, false, false, false, Set.of());
+        Study study = new Study(1L, "Title", true, "Info", "Finish", "preview", "Consent", null, null, null, null, List.of(observation), now, now, null);
+
+        when(studyService.getStudy(routingInfo)).thenReturn(Optional.of(Pair.of(study, Collections.emptyList())));
+        when(observationComponent.produceUrl(any(), any(), any(), any())).thenReturn(Optional.of("http://test.com"));
+
+        String url = observationExecutionService.executeObservation(observationId, start, end, routingInfo, null).map(URI::toString).orElse(null);
+
+        assertEquals("http://test.com", url);
+    }
+
+    @Test
+    void testExecuteObservationInvalidStatus() {
+        String observationId = "1";
+        Instant now = Instant.now();
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+
+        Study study = new Study(1L, "Title", true, "Info", "Finish", "inactive", "Consent", null, null, null, null, List.of(), now, now, null);
+
+        when(studyService.getStudy(routingInfo)).thenReturn(Optional.of(Pair.of(study, Collections.emptyList())));
+
+        assertThrows(ForbiddenException.class, () -> observationExecutionService.executeObservation(observationId, now, now, routingInfo, null));
+    }
+
+    @Test
+    void testExecuteObservationNotFound() {
+        String observationId = "1";
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+
+        when(studyService.getStudy(routingInfo)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> observationExecutionService.executeObservation(observationId, Instant.now(), Instant.now(), routingInfo, null));
+    }
+
+    @Test
+    void testExecuteObservationInvalidSchedule() {
+        String observationId = "1";
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        Instant start = now.plus(1, ChronoUnit.HOURS);
+        Instant end = start.plus(1, ChronoUnit.HOURS);
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+
+        Event event = new Event();
+        event.setDateStart(start);
+        event.setDateEnd(end);
+
+        Observation observation = new Observation(1, 1, "Title", "test-type", "Info", null, event, now, now, false, false, false, Set.of());
+        Study study = new Study(1L, "Title", true, "Info", "Finish", "active", "Consent", null, null, null, null, List.of(observation), now, now, null);
+
+        when(studyService.getStudy(routingInfo)).thenReturn(Optional.of(Pair.of(study, Collections.emptyList())));
+
+        // Wrong schedule
+        assertThrows(ForbiddenException.class, () -> observationExecutionService.executeObservation(observationId, start.minusSeconds(1), end, routingInfo, null));
+    }
+
+    @Test
+    void testExecuteObservationWithStudyDates() {
+        String observationId = "1";
+        java.time.LocalDate today = java.time.LocalDate.now();
+        java.time.ZoneId zoneId = java.time.ZoneId.systemDefault();
+
+        Instant scheduleStart = today.atTime(10, 0).atZone(zoneId).toInstant();
+        Instant scheduleEnd = today.atTime(11, 0).atZone(zoneId).toInstant();
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, java.util.OptionalInt.empty(), java.util.Set.of(), true, true);
+
+        Event event = new Event();
+        event.setDateStart(scheduleStart);
+        event.setDateEnd(scheduleEnd);
+
+        Observation observation = new Observation(1, 1, "Title", "test-type", "Info", null, event, Instant.now(), Instant.now(), false, false, false, java.util.Set.of());
+        Study study = new Study(1L, "Title", true, "Info", "Finish", "active", "Consent", null,
+                today.minusDays(1), null, today, List.of(observation), Instant.now(), Instant.now(), null);
+
+        when(studyService.getStudy(routingInfo)).thenReturn(Optional.of(Pair.of(study, Collections.emptyList())));
+        when(observationComponent.produceUrl(any(), any(), any(), any())).thenReturn(Optional.of("http://test.com"));
+
+        String url = observationExecutionService.executeObservation(observationId, scheduleStart, scheduleEnd, routingInfo, null).map(URI::toString).orElse(null);
+
+        assertEquals("http://test.com", url);
+    }
+
+    @Test
+    void testProcessCallback() {
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+        Map<String, String> parameters = Map.of("key", "value");
+
+        when(observationComponent.necessaryCallbackParameters(any())).thenReturn(true);
+        when(observationComponent.processCallback(any())).thenReturn(Optional.of(new CallbackResult(routingInfo, 1)));
+
+        observationExecutionService.processCallback(parameters);
+
+        verify(observationComponent).processCallback(eq(parameters));
+    }
+
+    @Test
+    void testProcessCallbackFallback() {
+        Map<String, String> parameters = Map.of("key", "value");
+
+        when(observationComponent.necessaryCallbackParameters(any())).thenReturn(false);
+
+        Optional<URI> result = observationExecutionService.processCallback(parameters);
+
+        assertFalse(result.isPresent());
+    }
+}

--- a/src/test/java/io/redlink/more/data/service/StudyServiceTest.java
+++ b/src/test/java/io/redlink/more/data/service/StudyServiceTest.java
@@ -1,0 +1,155 @@
+package io.redlink.more.data.service;
+
+import io.redlink.more.data.model.Contact;
+import io.redlink.more.data.model.ParticipantObservationSeed;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.model.SimpleParticipant;
+import io.redlink.more.data.model.Study;
+import io.redlink.more.data.repository.StudyRepository;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class StudyServiceTest {
+    @Mock
+    private StudyRepository studyRepository;
+
+    private StudyService studyService;
+
+    @BeforeEach
+    void init() {
+        studyService = new StudyService(studyRepository);
+    }
+
+    @Test
+    void testGetRoutingInfo() {
+        long studyId = 1L;
+        int participantId = 1;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        when(studyRepository.getRoutingInfo(studyId, participantId)).thenReturn(Optional.of(routingInfo));
+
+        Optional<RoutingInfo> result = studyService.getRoutingInfo(studyId, participantId);
+
+        assertTrue(result.isPresent());
+        assertEquals(routingInfo, result.get());
+        verify(studyRepository).getRoutingInfo(studyId, participantId);
+    }
+
+    @Test
+    void testGetStudySuccess() {
+        long studyId = 1L;
+        int participantId = 1;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        Study study = new Study(studyId, "Title", true, "Info", "Finish", "active", "Consent",
+                new Contact("Inst", "Person", "email", "phone"),
+                LocalDate.now(), LocalDate.now(), LocalDate.now().plusDays(10),
+                Collections.emptyList(), Instant.now(), Instant.now(),
+                new SimpleParticipant(participantId, "alias", Instant.now(), Instant.now().plus(Duration.ofDays(10))));
+
+        when(studyRepository.findStudy(routingInfo)).thenReturn(Optional.of(study));
+        when(studyRepository.getAllParticpantObservationProperties(studyId, participantId)).thenReturn(Collections.emptyList());
+
+        Optional<Pair<Study, List<ParticipantObservationSeed>>> result = studyService.getStudy(routingInfo);
+
+        assertTrue(result.isPresent());
+        assertEquals(study, result.get().getLeft());
+        assertTrue(result.get().getRight().isEmpty());
+    }
+
+    @Test
+    void testGetStudyInactive() {
+        long studyId = 1L;
+        int participantId = 1;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        Study study = new Study(studyId, "Title", false, "Info", "Finish", "active", "Consent",
+                new Contact("Inst", "Person", "email", "phone"),
+                LocalDate.now(), LocalDate.now(), LocalDate.now().plusDays(10),
+                Collections.emptyList(), Instant.now(), Instant.now(),
+                new SimpleParticipant(participantId, "alias", Instant.now(), Instant.now().plus(Duration.ofDays(10))));
+
+        when(studyRepository.findStudy(routingInfo)).thenReturn(Optional.of(study));
+
+        Optional<Pair<Study, List<ParticipantObservationSeed>>> result = studyService.getStudy(routingInfo);
+
+        assertTrue(result.isPresent());
+        assertEquals(study, result.get().getLeft());
+        assertTrue(result.get().getRight().isEmpty());
+    }
+
+    @Test
+    void testGetStudyNullRoutingInfo() {
+        Optional<Pair<Study, List<ParticipantObservationSeed>>> result = studyService.getStudy(null);
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void testGetStudyNotFound() {
+        long studyId = 1L;
+        int participantId = 1;
+        RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
+        when(studyRepository.findStudy(routingInfo)).thenReturn(Optional.empty());
+
+        Optional<Pair<Study, List<ParticipantObservationSeed>>> result = studyService.getStudy(routingInfo);
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void testGetParticipantObservationSeedsEmpty() {
+        long studyId = 1L;
+        int participantId = 1;
+        when(studyRepository.getAllParticpantObservationProperties(studyId, participantId)).thenReturn(Collections.emptyList());
+
+        List<ParticipantObservationSeed> result = studyService.getParticipantObservationSeeds(studyId, participantId);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetParticipantObservationSeedsSuccess() {
+        long studyId = 1L;
+        int participantId = 1;
+        io.redlink.more.data.model.ParticipantWithObservationProperties props = new io.redlink.more.data.model.ParticipantWithObservationProperties(
+                participantId, studyId, 100, java.util.Map.of("observation_schedule_seed", 12345L)
+        );
+        when(studyRepository.getAllParticpantObservationProperties(studyId, participantId)).thenReturn(List.of(props));
+
+        List<ParticipantObservationSeed> result = studyService.getParticipantObservationSeeds(studyId, participantId);
+
+        assertEquals(1, result.size());
+        assertEquals(100, result.get(0).observationId());
+        assertEquals(12345L, result.get(0).seed());
+    }
+
+    @Test
+    void testGetParticipantObservationSeedsFilterNoSeed() {
+        long studyId = 1L;
+        int participantId = 1;
+        io.redlink.more.data.model.ParticipantWithObservationProperties props = new io.redlink.more.data.model.ParticipantWithObservationProperties(
+                participantId, studyId, 100, java.util.Map.of()
+        );
+        when(studyRepository.getAllParticpantObservationProperties(studyId, participantId)).thenReturn(List.of(props));
+
+        List<ParticipantObservationSeed> result = studyService.getParticipantObservationSeeds(studyId, participantId);
+
+        assertTrue(result.isEmpty());
+    }
+
+}

--- a/src/test/java/io/redlink/more/data/service/observations/limesurvey/LimeSurveyComponentTest.java
+++ b/src/test/java/io/redlink/more/data/service/observations/limesurvey/LimeSurveyComponentTest.java
@@ -1,0 +1,114 @@
+package io.redlink.more.data.service.observations.limesurvey;
+
+import io.redlink.more.data.model.CallbackResult;
+import io.redlink.more.data.model.Observation;
+import io.redlink.more.data.model.RoutingInfo;
+import io.redlink.more.data.model.RoutingInfoWithObservation;
+import io.redlink.more.data.service.ElasticService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LimeSurveyComponentTest {
+
+    @Mock
+    private LimeSurveyRequestService limeSurveyRequestService;
+
+    @Mock
+    private ElasticService elasticService;
+
+    @Mock
+    private io.redlink.more.data.service.StudyService studyService;
+
+    private LimeSurveyComponent limeSurveyComponent;
+
+    @BeforeEach
+    void setUp() {
+        limeSurveyComponent = new LimeSurveyComponent(limeSurveyRequestService, elasticService, studyService);
+    }
+
+    @Test
+    void testGetObservationType() {
+        assertEquals("lime-survey-observation", limeSurveyComponent.getObservationType());
+    }
+
+    @Test
+    void testProduceUrl() {
+        Map<String, Object> properties = Map.of(
+                "limeSurveyId", "123",
+                "token", "abc",
+                "limeUrl", "http://limesurvey.example.com"
+        );
+        Observation observation = new Observation(1, 1, "Title", "lime-survey-observation", "Info", properties, null, Instant.now(), Instant.now(), false, false, false, Set.of());
+
+        Optional<String> url = limeSurveyComponent.produceUrl(observation, null, null, null);
+
+        assertTrue(url.isPresent());
+        assertTrue(url.get().contains("123"));
+        assertTrue(url.get().contains("token=abc"));
+    }
+
+    @Test
+    void testProcessCallbackSuccess() throws Exception {
+        Map<String, String> parameters = Map.of(
+                "token", "token123",
+                "saveId", "50",
+                "surveyId", "100",
+                "studyId", "1",
+                "observationId", "1"
+        );
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+
+        when(studyService.getRoutingInfoByToken(1L, "token123")).thenReturn(Optional.of(new RoutingInfoWithObservation(routingInfo, 1)));
+        when(limeSurveyRequestService.getAnswer("token123", 100, 50))
+                .thenReturn(Optional.of(new java.util.HashMap<>(Map.of("some_key", "some_value"))));
+
+        Optional<CallbackResult> result = limeSurveyComponent.processCallback(parameters);
+        assertTrue(result.isPresent());
+        assertEquals(routingInfo, result.get().routingInfo());
+        assertEquals(1, result.get().observationId());
+        verify(elasticService).storeDataPoints(anyList(), eq(routingInfo));
+    }
+
+    @Test
+    void testProcessCallbackFallbackSuccess() throws Exception {
+        Map<String, String> parameters = Map.of(
+                "saveId", "50",
+                "surveyId", "100",
+                "studyid", "1",
+                "observationid", "1",
+                "token", "token123"
+        );
+        RoutingInfo routingInfo = new RoutingInfo(1L, 1, OptionalInt.empty(), Set.of(), true, true);
+
+        when(studyService.getRoutingInfoByToken(1L, "token123")).thenReturn(Optional.of(new RoutingInfoWithObservation(routingInfo, 1)));
+        when(limeSurveyRequestService.getAnswer("token123", 100, 50))
+                .thenReturn(Optional.of(new java.util.HashMap<>(Map.of("some_key", "some_value"))));
+
+        Optional<CallbackResult> result = limeSurveyComponent.processCallback(parameters);
+        assertTrue(result.isPresent());
+        assertEquals(routingInfo, result.get().routingInfo());
+        assertEquals(1, result.get().observationId());
+        verify(elasticService).storeDataPoints(anyList(), eq(routingInfo));
+    }
+
+    @Test
+    void testProcessCallbackMissingParams() {
+        Map<String, String> parameters = Map.of("token", "token123");
+
+        assertThrows(IllegalArgumentException.class, () -> limeSurveyComponent.processCallback(parameters));
+    }
+}

--- a/src/test/java/io/redlink/more/data/service/observations/limesurvey/LimeSurveyRequestServiceTest.java
+++ b/src/test/java/io/redlink/more/data/service/observations/limesurvey/LimeSurveyRequestServiceTest.java
@@ -1,0 +1,131 @@
+package io.redlink.more.data.service.observations.limesurvey;
+
+import io.redlink.more.data.limesurvey.client.LimeSurveyRcApi;
+import io.redlink.more.data.limesurvey.model.LimeSurveyMethod;
+import io.redlink.more.data.limesurvey.model.LimeSurveyObjectResponse;
+import io.redlink.more.data.limesurvey.model.LimeSurveyRequest;
+import io.redlink.more.data.service.observations.limesurvey.config.LimeSurveyProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LimeSurveyRequestServiceTest {
+
+    @Mock
+    private LimeSurveyRcApi limeSurveyRcApi;
+
+    @Mock
+    private LimeSurveyProperties properties;
+
+    private LimeSurveyRequestService limeSurveyRequestService;
+
+    @BeforeEach
+    void setUp() {
+        when(properties.getUsername()).thenReturn("user");
+        when(properties.getPassword()).thenReturn("pass");
+        limeSurveyRequestService = new LimeSurveyRequestService(limeSurveyRcApi, properties);
+    }
+
+    @Test
+    void testGetLanguageSuccess() {
+        String sessionKey = "session123";
+        String surveyId = "100";
+        LimeSurveyObjectResponse response = new LimeSurveyObjectResponse();
+        response.setResult(Map.of("surveyls_language", "en"));
+
+        ArgumentCaptor<LimeSurveyRequest> requestCaptor = ArgumentCaptor.forClass(LimeSurveyRequest.class);
+        when(limeSurveyRcApi.callMethod(requestCaptor.capture())).thenReturn(response);
+
+        String lang = limeSurveyRequestService.getLanguage(surveyId, sessionKey);
+
+        assertEquals("en", lang);
+        LimeSurveyRequest request = requestCaptor.getValue();
+        assertEquals(LimeSurveyMethod.GET_LANGUAGE_PROPERTIES, request.getMethod());
+        assertEquals(1, request.getId());
+        assertEquals(LimeSurveyRequest.JsonrpcEnum._2_0, request.getJsonrpc());
+    }
+
+    @Test
+    void testGetLanguageError() {
+        String sessionKey = "session123";
+        String surveyId = "100";
+        LimeSurveyObjectResponse response = new LimeSurveyObjectResponse();
+        response.setError("Some error");
+
+        when(limeSurveyRcApi.callMethod(any())).thenReturn(response);
+
+        assertThrows(RuntimeException.class, () -> limeSurveyRequestService.getLanguage(surveyId, sessionKey));
+    }
+
+    @Test
+    void testGetAnswerSuccess() throws Exception {
+        String token = "token123";
+        int surveyId = 100;
+        int savedId = 50;
+        String sessionKey = "session123";
+
+        LimeSurveyObjectResponse sessionResponse = new LimeSurveyObjectResponse();
+        sessionResponse.setResult(sessionKey);
+
+        LimeSurveyObjectResponse langResponse = new LimeSurveyObjectResponse();
+        langResponse.setResult(Map.of("surveyls_language", "en"));
+
+        LimeSurveyObjectResponse exportResponse = new LimeSurveyObjectResponse();
+        Map<String, Object> responseData = Map.of("responses", List.of(Map.of("Response ID", "50", "some_answer", "yes")));
+        String encoded = Base64.getEncoder().encodeToString(new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsBytes(responseData));
+        exportResponse.setResult(encoded);
+
+        when(limeSurveyRcApi.callMethod(any()))
+                .thenReturn(sessionResponse) // 1. getSessionKey
+                .thenReturn(langResponse)    // 2. getLanguage
+                .thenReturn(exportResponse)  // 3. export_responses_by_token
+                .thenReturn(new LimeSurveyObjectResponse()); // 4. releaseSessionKey
+
+        Optional<Map<String, Object>> result = limeSurveyRequestService.getAnswer(token, surveyId, savedId);
+
+        assertTrue(result.isPresent());
+        assertEquals("50", String.valueOf(result.get().get("Response ID")));
+        assertEquals("yes", result.get().get("some_answer"));
+    }
+
+    @Test
+    void testGetAnswerNotFound() {
+        String token = "token123";
+        int surveyId = 100;
+        int savedId = 50;
+        String sessionKey = "session123";
+
+        LimeSurveyObjectResponse sessionResponse = new LimeSurveyObjectResponse();
+        sessionResponse.setResult(sessionKey);
+        LimeSurveyObjectResponse langResponse = new LimeSurveyObjectResponse();
+        langResponse.setResult(Map.of("surveyls_language", "en"));
+        LimeSurveyObjectResponse exportResponse = new LimeSurveyObjectResponse();
+        exportResponse.setResult(null);
+
+        when(limeSurveyRcApi.callMethod(any()))
+                .thenReturn(sessionResponse)
+                .thenReturn(langResponse)
+                .thenReturn(exportResponse)
+                .thenReturn(new LimeSurveyObjectResponse()); // releaseSessionKey
+
+        Optional<Map<String, Object>> result = limeSurveyRequestService.getAnswer(token, surveyId, savedId);
+
+        assertTrue(result.isEmpty());
+    }
+}

--- a/src/test/java/io/redlink/more/data/service/observations/limesurvey/config/LimeSurveyConfigurationTest.java
+++ b/src/test/java/io/redlink/more/data/service/observations/limesurvey/config/LimeSurveyConfigurationTest.java
@@ -1,0 +1,64 @@
+package io.redlink.more.data.service.observations.limesurvey.config;
+
+import io.redlink.more.data.limesurvey.client.LimeSurveyRcApi;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LimeSurveyConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ConfigurationPropertiesAutoConfiguration.class))
+            .withUserConfiguration(LimeSurveyConfiguration.class, LimeSurveyProperties.class);
+
+    @Test
+    void testLimeSurveyRcApiBean() {
+        contextRunner
+                .withPropertyValues(
+                        "more.limesurvey.username=admin",
+                        "more.limesurvey.password=admin",
+                        "more.limesurvey.baseUrl=https://lime.example.com/index.php"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(LimeSurveyRcApi.class);
+                    LimeSurveyRcApi api = context.getBean(LimeSurveyRcApi.class);
+                    assertThat(api.getApiClient().getBasePath())
+                            .isEqualTo("https://lime.example.com/index.php/admin/remotecontrol");
+                });
+    }
+
+    @Test
+    void testLimeSurveyRcApiBeanWithTrailingSlash() {
+        contextRunner
+                .withPropertyValues(
+                        "more.limesurvey.username=admin",
+                        "more.limesurvey.password=admin",
+                        "more.limesurvey.baseUrl=https://lime.example.com/index.php"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(LimeSurveyRcApi.class);
+                    LimeSurveyRcApi api = context.getBean(LimeSurveyRcApi.class);
+                    assertThat(api.getApiClient().getBasePath())
+                            .isEqualTo("https://lime.example.com/index.php/admin/remotecontrol");
+                });
+    }
+
+    @Test
+    void testLimeSurveyRcApiBeanWithSubdir() {
+        contextRunner
+                .withPropertyValues(
+                        "more.limesurvey.username=admin",
+                        "more.limesurvey.password=admin",
+                        "more.limesurvey.baseUrl=https://lime.example.com/index.php/limesurvey"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(LimeSurveyRcApi.class);
+                    LimeSurveyRcApi api = context.getBean(LimeSurveyRcApi.class);
+                    assertThat(api.getApiClient().getBasePath())
+                            .isEqualTo("https://lime.example.com/index.php/limesurvey/admin/remotecontrol");
+                });
+    }
+}

--- a/src/test/java/io/redlink/more/data/store/observationCallback/InMemoryObservationCallbackStoreTest.java
+++ b/src/test/java/io/redlink/more/data/store/observationCallback/InMemoryObservationCallbackStoreTest.java
@@ -1,0 +1,66 @@
+package io.redlink.more.data.store.observationCallback;
+
+import io.redlink.more.data.model.ActiveObservation;
+import io.redlink.more.data.model.RoutingInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InMemoryObservationCallbackStoreTest {
+
+    private InMemoryObservationCallbackStore store;
+    private RoutingInfo routingInfo;
+    private ActiveObservation activeObservation;
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryObservationCallbackStore();
+        routingInfo = new RoutingInfo(1L, 1, java.util.OptionalInt.empty(), Set.of(), true, true);
+        activeObservation = new ActiveObservation("1", Instant.now().truncatedTo(ChronoUnit.SECONDS), Instant.now().plus(1, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @Test
+    void testSaveAndPullRedirect() {
+        String redirectUrl = "http://test.com/redirect";
+        store.saveRedirect(routingInfo, activeObservation, redirectUrl);
+
+        Optional<URI> pulled = store.pullRedirect(routingInfo, 1);
+        assertTrue(pulled.isPresent());
+        assertEquals(redirectUrl, pulled.get().toString());
+
+        // Should be empty after pull
+        assertTrue(store.pullRedirect(routingInfo, 1).isEmpty());
+    }
+
+    @Test
+    void testMarkAndIsCompleted() {
+        assertFalse(store.isCompleted(routingInfo, activeObservation));
+        store.markCompleted(routingInfo, activeObservation);
+        assertTrue(store.isCompleted(routingInfo, activeObservation));
+    }
+
+    @Test
+    void testPullRedirectMarksAsCompleted() {
+        String redirectUrl = "http://test.com/redirect";
+        store.saveRedirect(routingInfo, activeObservation, redirectUrl);
+
+        assertFalse(store.isCompleted(routingInfo, activeObservation));
+        store.pullRedirect(routingInfo, 1);
+        assertTrue(store.isCompleted(routingInfo, activeObservation));
+    }
+
+    @Test
+    void testGetCompletedData() {
+        store.markCompleted(routingInfo, activeObservation);
+        var completed = store.getCompletedData(routingInfo);
+        assertEquals(1, completed.size());
+        assertEquals(activeObservation.observationId(), completed.get(0).observationId());
+    }
+}

--- a/src/test/java/io/redlink/more/data/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/redlink/more/data/util/DateTimeUtilsTest.java
@@ -4,7 +4,9 @@ import org.apache.commons.lang3.Range;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Set;
+import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -58,5 +60,93 @@ class DateTimeUtilsTest {
         Set<Range<Instant>> merged2 = DateTimeUtils.mergeRanges(Set.of(r4, r5));
         assertEquals(1, merged2.size());
         assertTrue(merged2.contains(r4));
+    }
+
+    @Test
+    void testParseInstantUsesSystemTimezoneOffset() {
+        TimeZone originalTimeZone = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("GMT+02:00"));
+
+            assertEquals(
+                    Instant.parse("2022-12-31T22:00:00Z"),
+                    DateTimeUtils.parseInstant("2023-01-01")
+            );
+            assertEquals(
+                    Instant.parse("2023-01-01T08:00:00Z"),
+                    DateTimeUtils.parseInstant("2023-01-01 10:00:00")
+            );
+        } finally {
+            TimeZone.setDefault(originalTimeZone);
+        }
+    }
+
+    @Test
+    void testParseInstantKeepsExplicitInstantIndependentOfSystemOffset() {
+        TimeZone originalTimeZone = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("GMT+02:00"));
+
+            assertEquals(
+                    Instant.parse("2023-01-01T10:00:00Z"),
+                    DateTimeUtils.parseInstant("2023-01-01T10:00:00Z")
+            );
+        } finally {
+            TimeZone.setDefault(originalTimeZone);
+        }
+    }
+
+    @Test
+    void testParseInstantNullOrBlankReturnsNull() {
+        assertNull(DateTimeUtils.parseInstant(null));
+        assertNull(DateTimeUtils.parseInstant(""));
+        assertNull(DateTimeUtils.parseInstant("   "));
+    }
+
+    @Test
+    void testParseInstantInvalidInputThrowsException() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateTimeUtils.parseInstant("not-a-date")
+        );
+    }
+
+    @Test
+    void testParseInstantWithOffsetPositiveOffset() {
+        ZoneOffset offset = ZoneOffset.ofHours(2);
+
+        assertEquals(Instant.parse("2022-12-31T22:00:00Z"), DateTimeUtils.parseInstantWithOffset("2023-01-01", offset));
+        assertEquals(Instant.parse("2023-01-01T08:00:00Z"), DateTimeUtils.parseInstantWithOffset("2023-01-01 10:00:00", offset));
+    }
+
+    @Test
+    void testParseInstantWithOffsetNegativeOffset() {
+        ZoneOffset offset = ZoneOffset.ofHours(-5);
+
+        assertEquals(Instant.parse("2023-01-01T05:00:00Z"), DateTimeUtils.parseInstantWithOffset("2023-01-01", offset));
+        assertEquals(Instant.parse("2023-01-01T15:00:00Z"), DateTimeUtils.parseInstantWithOffset("2023-01-01 10:00:00", offset));
+    }
+
+    @Test
+    void testParseInstantWithOffsetKeepsExplicitInstantIndependentOfOffset() {
+        assertEquals(
+                Instant.parse("2023-01-01T10:00:00Z"),
+                DateTimeUtils.parseInstantWithOffset("2023-01-01T10:00:00Z", ZoneOffset.ofHours(2))
+        );
+    }
+
+    @Test
+    void testParseInstantWithOffsetNullOrBlankReturnsNull() {
+        assertNull(DateTimeUtils.parseInstantWithOffset(null, ZoneOffset.ofHours(2)));
+        assertNull(DateTimeUtils.parseInstantWithOffset("", ZoneOffset.ofHours(2)));
+        assertNull(DateTimeUtils.parseInstantWithOffset("   ", ZoneOffset.ofHours(2)));
+    }
+
+    @Test
+    void testParseInstantWithOffsetInvalidInputThrowsException() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DateTimeUtils.parseInstantWithOffset("not-a-date", ZoneOffset.ofHours(2))
+        );
     }
 }

--- a/src/test/java/io/redlink/more/data/util/ParticipantUtilsTest.java
+++ b/src/test/java/io/redlink/more/data/util/ParticipantUtilsTest.java
@@ -1,0 +1,66 @@
+package io.redlink.more.data.util;
+
+import io.redlink.more.data.model.ParticipantConsent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ParticipantUtilsTest {
+
+    @Test
+    void testObfuscate() {
+        assertEquals("unknown", ParticipantUtils.obfuscate(null));
+        assertEquals("unknown", ParticipantUtils.obfuscate(""));
+
+        // With delimiter
+        assertEquals("Model#123456789012", ParticipantUtils.obfuscate("Model#123456789012")); // Exactly 12, not obfuscated
+        assertEquals("Model#123456...890123", ParticipantUtils.obfuscate("Model#1234567890123"));
+        assertEquals("Model#123", ParticipantUtils.obfuscate("Model#123"));
+        assertEquals("unknown#123456...890123", ParticipantUtils.obfuscate("#1234567890123"));
+
+        // Without delimiter
+        assertEquals("123456", ParticipantUtils.obfuscate("123456"));
+        assertEquals("123456...890123", ParticipantUtils.obfuscate("1234567890123"));
+    }
+
+    @Test
+    void testConvertAppDTO() {
+        io.redlink.more.data.api.app.v1.model.StudyConsentDTO dto = new io.redlink.more.data.api.app.v1.model.StudyConsentDTO();
+        dto.setConsent(true);
+        dto.setDeviceId("Device#1234567890123");
+        dto.setConsentInfoMD5("md5hash");
+
+        io.redlink.more.data.api.app.v1.model.ObservationConsentDTO obs = new io.redlink.more.data.api.app.v1.model.ObservationConsentDTO();
+        obs.setObservationId("1");
+        dto.setObservations(List.of(obs));
+
+        ParticipantConsent result = ParticipantUtils.convert(dto);
+        assertTrue(result.accepted());
+        assertEquals("Device#123456...890123", result.deviceId());
+        assertEquals("md5hash", result.consentMd5());
+        assertEquals(1, result.observationConsents().size());
+        assertEquals(1, result.observationConsents().get(0).observationId());
+    }
+
+    @Test
+    void testConvertParticipantDTO() {
+        io.redlink.more.data.api.participant.v1.model.StudyConsentDTO dto = new io.redlink.more.data.api.participant.v1.model.StudyConsentDTO();
+        dto.setConsent(true);
+        dto.setDeviceId("Device#1234567890123");
+        dto.setConsentInfoMD5("md5hash");
+
+        io.redlink.more.data.api.participant.v1.model.ObservationConsentDTO obs = new io.redlink.more.data.api.participant.v1.model.ObservationConsentDTO();
+        obs.setObservationId("2");
+        dto.setObservations(List.of(obs));
+
+        ParticipantConsent result = ParticipantUtils.convert(dto);
+        assertTrue(result.accepted());
+        assertEquals("Device#123456...890123", result.deviceId());
+        assertEquals("md5hash", result.consentMd5());
+        assertEquals(1, result.observationConsents().size());
+        assertEquals(2, result.observationConsents().get(0).observationId());
+    }
+}


### PR DESCRIPTION
* Corrected connection, developerConnection and url for the <scm> element

* Exploding batched data into seperate datapoints in elastic

* ts fix

* fixes to exploding polar360 data

* init

* Gateway tests added

* Revert polar360 feature commits accidentally pushed to develop

Reverts commits bdc8927, ec3c5c2, 3daf15c, eaccb12, 5fa1627 which belong to feature/polar360-split-observations branch.

* #1: CReated new PP OpenAPI Spec and tested it with impleemnting the generator in the gateway

* #1: OpenAPI Specs updates

* #1: OpenAPI Specs updates

* #1: OpenAPI Specs updates

* #469: Implemented the login token validation service for login in the participant in a given application

* #469: PR fix

* #469: Test fix

* #268: WIP commit

* Authentication is implemented (untested)
* Rest is Work in Progress
* Some Updates on OpenAPI Spec

* #268: Implemented webservices for participant portal api

* #268: PR changes

* #268: Application Crash fix

* #268: Application Crash fix

* #268: Application Crash fix

* #268: PAth fixes

* #268: Log in bug fixed and added a small logout route

* #268: Implemented a participant state change after accepting

* #268: PR fix

* prehab2rehab/#389: Fix Study State Bug to get correct states for completed, draft and preview

* prehab2rehab/#389: remove draft state from api and transformer

* #268: This changes the PP Controller to only return studies in an active or paused state. Also refactored the Controller to a single Controller implementation that implements both APIs to better share common functionality.

* #279: Refactoring as preparation: Study- and ObservationGroups can change for paused Studies. As we allow for interactions with the PP in the paused states, we MUST ensure that `RoutingInfo` is updated on every request. To enforce this the session now only stores the `studyId` and `participantId`.

* changed APIs to use `studyId` and `participantId` instead of `RoutingInfo` where applicable
* updated Service, Controller and Tests to the changes.

Only Refactoring. This commit introduces no functional change

* * renamed `participantportal` package - packages are not camelcase!
* moved the ParticipantPortalControllerTest in the same package as the implementation

* minor

* Fixed an issue with a record serialization

* #15: Added deployment tags to the pipeline

* #15: Added deployment tags to the pipeline

* #280: Implementation of the DataHealth repository and service based on occurred_observation data in the MORE data base

* #281: Add dataHealth state in the RestAPI

* #281; implementation of the DataHealth state for the ParticipantPortal.

* ZoneId troubles with the unitTest

* #285: Implemented a new webservice that redirects to the correct limesurvey and then back to the origin

* #285: Integrated data health

* Added Logging for DataHealth requests

* #285:PR fix

* #285:PR fix

* #281: Fixed the unexpected `invalid` state for DataHealth; changed Jackson default to only include properties that are not null; deactivated DEBUG logging for the `ParticipantPortalController`

* #281: the Jackson configuration change also changed the response

* #285: PR fixes

* #285: PR fixes

* #285: Data storage fixes

* #285: PR fixes

* #285: PR fixes

* #281: remove the default as this breaks backward compatibility with the app

* #285: Disabled same-site cookie session

* #285: Disabled same-site cookie session

* #285: Implemented redirects, based on routinginfo not session cookies

* #285: PR fix

* #285: Moved callback redirction storage to inmemory

* #285: PR changes

* #285: Fixed a startup Issue

* Fixed a deployment issue

* Fixed a deployment issue

* #1: Implemented function so LS data are stored using an offset of 0 and moved the limesurvey link generation from using the properties to using the lime base url env variable

* #1: PR fix and improved the storage of any date fields in LimeSurvey data

* #304: Added logging for better observability

* #304: Added logging for better observability

* #304: Added logging for better observability

* #3ß3 add log statement for callbacks processed by the gateway

* #303: added more logs for the callback processing

* #304: Cleanup and logging for better observability

* #304: Cleanup and logging for better observability

* #304: Removed studyId and observationId from being read from the limesurvey redirect url parameters for cross study usage

* #304: Implemented ls participant quering before trying to get a participant by only using a the ls token

* prehab2rehab/#45: remove participant id for ParticipantPortal

* prehab2rehab/#45: remove .id setter completely in ParticipantPortalTransformer

* Implemented a small change to better handle limesurvey

---------