### PR TITLE
#288: Goal Data Storage

### DIFF
--- a/src/main/java/io/redlink/more/data/configuration/SecurityConfig.java
+++ b/src/main/java/io/redlink/more/data/configuration/SecurityConfig.java
@@ -83,7 +83,7 @@ public class SecurityConfig {
                     // all other apis require credentials
                     req.requestMatchers("/api/v1/**")
                             .authenticated();
-                    req.requestMatchers("goals/api/v1/**")
+                    req.requestMatchers("/goals/api/v1/**")
                             .authenticated();
                     req.requestMatchers("/participant-portal/api/v1/**")
                             .authenticated();

--- a/src/main/java/io/redlink/more/data/controller/GlobalControllerExceptionHandler.java
+++ b/src/main/java/io/redlink/more/data/controller/GlobalControllerExceptionHandler.java
@@ -3,6 +3,7 @@ package io.redlink.more.data.controller;
 import io.redlink.more.data.api.app.v1.model.ErrorDTO;
 import io.redlink.more.data.controller.transformer.ErrorTransformer;
 import io.redlink.more.data.exception.BadRequestException;
+import io.redlink.more.data.exception.ConflictException;
 import io.redlink.more.data.exception.ForbiddenException;
 import io.redlink.more.data.exception.NotAuthorizedException;
 import io.redlink.more.data.exception.NotFoundException;
@@ -24,6 +25,12 @@ public class GlobalControllerExceptionHandler {
     public ResponseEntity<Void> handleForbidden(ForbiddenException e) {
         LOG.warn("Forbidden: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<Void> handleConflict(ConflictException e) {
+        LOG.warn("Conflict: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).build();
     }
 
     @ExceptionHandler(NotFoundException.class)

--- a/src/main/java/io/redlink/more/data/controller/goal/GoalConfigController.java
+++ b/src/main/java/io/redlink/more/data/controller/goal/GoalConfigController.java
@@ -16,12 +16,17 @@ import io.redlink.more.data.service.StudyService;
 import io.redlink.more.data.service.goal.GoalService;
 import io.redlink.more.data.util.LoggingUtils;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Controller
 @RestController
+@RequestMapping(value = "/goals/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
 public class GoalConfigController implements GoalsConfigApi, GoalTemplatesApi {
 
     private final AuthenticationFacade authenticationFacade;

--- a/src/main/java/io/redlink/more/data/controller/goal/GoalController.java
+++ b/src/main/java/io/redlink/more/data/controller/goal/GoalController.java
@@ -12,7 +12,10 @@ import io.redlink.more.data.service.GatewayUserDetailService;
 import io.redlink.more.data.service.goal.GoalService;
 import io.redlink.more.data.util.LoggingUtils;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
@@ -20,7 +23,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Controller
 @RestController
+@RequestMapping(value = "/goals/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
 public class GoalController implements GoalsApi {
 
     private final AuthenticationFacade authenticationFacade;

--- a/src/main/java/io/redlink/more/data/controller/transformer/DataTransformer.java
+++ b/src/main/java/io/redlink/more/data/controller/transformer/DataTransformer.java
@@ -10,6 +10,7 @@ import io.redlink.more.data.api.app.v1.model.ObservationDataDTO;
 import io.redlink.more.data.model.ApiRoutingInfo;
 import io.redlink.more.data.model.DataPoint;
 import io.redlink.more.data.util.MapperUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.time.Instant;
 import java.util.List;
@@ -34,7 +35,7 @@ public final class DataTransformer {
                 dataPoint.getDataId(),
                 dataPoint.getObservationId(),
                 dataPoint.getObservationType(),
-                dataPoint.getObservationType(),
+                StringUtils.isBlank(dataPoint.getDataType()) ? dataPoint.getObservationType() : dataPoint.getDataType(),
                 recordingTime,
                 dateTime,
                 MapperUtils.convertValue(dataPoint.getDataValue(), Map.class)
@@ -54,7 +55,7 @@ public final class DataTransformer {
                 UUID.randomUUID().toString(),
                 observationId.toString(),
                 routingInfo.observationType(),
-                routingInfo.observationType(),
+                StringUtils.isBlank(dataPoint.getDataType()) ? routingInfo.observationType(): dataPoint.getDataType(),
                 recordingTime,
                 dateTime,
                 dataPoint.getDataValue());

--- a/src/main/java/io/redlink/more/data/controller/transformer/GoalTransformer.java
+++ b/src/main/java/io/redlink/more/data/controller/transformer/GoalTransformer.java
@@ -87,7 +87,7 @@ public final class GoalTransformer {
                 List.of();
 
         return new GoalTemplateDTO(
-                Objects.toString(template.getTemplateId()),
+                template.getExternalTemplateId(),
                 template.getParticipantTitle() != null ?
                         template.getParticipantTitle() : //NOTE: the ParticipantTitle is mapped to the title
                         template.getTitle(), //the internal title is used as fallback
@@ -113,8 +113,8 @@ public final class GoalTransformer {
                 List.of();
 
         return new GoalDTO()
-                .goalId(Objects.toString(goal.getGoalId()))
-                .templateId(Objects.toString(goal.getTemplateId()))
+                .goalId(goal.getExternalGoalId())
+                .templateId(goal.getExternalTemplateId())
                 .created(goal.getCreated())
                 .title(goal.getTitle())
                 .adherenceChecks(adherenceChecks)
@@ -127,7 +127,7 @@ public final class GoalTransformer {
         Goal goal = new Goal()
                 .setStudyId(studyId)
                 .setParticipantId(participantId)
-                .setTemplateId(parseId(dto.getTemplateId()))
+                .setTemplateId(GoalTemplate.parseExternalTemplateId(dto.getTemplateId()))
                 .setTitle(dto.getTitle());
 
         // Adherence Checks: Enum → Ordinal

--- a/src/main/java/io/redlink/more/data/elastic/model/ElasticDataPoint.java
+++ b/src/main/java/io/redlink/more/data/elastic/model/ElasticDataPoint.java
@@ -15,6 +15,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.redlink.more.data.model.DataPoint;
 import io.redlink.more.data.model.RoutingInfo;
+import org.apache.commons.lang3.StringUtils;
+
 import java.time.Instant;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -30,6 +32,8 @@ public record ElasticDataPoint(
         String studyGroupId,
         @JsonProperty("observation_id")
         String observationId,
+        @JsonProperty("instance_id")
+        String instanceId,
         @JsonProperty("observation_type")
         String observationType,
         @JsonProperty("data_type")
@@ -64,6 +68,11 @@ public record ElasticDataPoint(
     }
 
     public static ElasticDataPoint toElastic(DataPoint dataPoint, RoutingInfo elasticInfo) {
+        var observationIdParts = StringUtils.split(dataPoint.observationId(),':');
+        if(observationIdParts.length > 2) { //NOTE: no full validation, just a smoke test
+            throw new IllegalStateException("Illegal formatted observation id: " + dataPoint.observationId() +
+                    "(Expected <observation-id>[:<instance-id>],  Format: ^[\\w-]+(:[\\w-]+)?$");
+        }
         return new ElasticDataPoint(
                 dataPoint.datapointId(),
                 "participant_%d".formatted(elasticInfo.participantId()),
@@ -73,9 +82,10 @@ public record ElasticDataPoint(
                         .findFirst()
                         .orElse(null),
                 //TODO: Do we need observation groups in the Elastic index. I am not sure (westei, 18.12.2025)
-                dataPoint.observationId(),
+                observationIdParts[0],
+                observationIdParts.length > 1 ? observationIdParts[1] : null,
                 dataPoint.observationType(),
-                dataPoint.dataType(),
+                dataPoint.dataType() == null ? dataPoint.observationType() : dataPoint.dataType(),
                 dataPoint.serverTime(),
                 dataPoint.effectiveDateTime(),
                 dataPoint.data()

--- a/src/main/java/io/redlink/more/data/model/goal/Goal.java
+++ b/src/main/java/io/redlink/more/data/model/goal/Goal.java
@@ -1,10 +1,19 @@
 package io.redlink.more.data.model.goal;
 
+import io.redlink.more.data.exception.ConflictException;
+
 import java.time.Instant;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Goal {
+
+    public static final String GOAL_ID_PREFIX = "goal-";
+    private static final Pattern PATTERN_GOAL_ID = Pattern.compile("^" + GOAL_ID_PREFIX + "(\\d+)$");
+
     private Long studyId;
     private Integer goalId;
     private Integer participantId;
@@ -22,11 +31,22 @@ public class Goal {
     public Integer getGoalId() { return goalId; }
     public Goal setGoalId(Integer goalId) { this.goalId = goalId; return this; }
 
+    public String getExternalGoalId(){
+        return GOAL_ID_PREFIX + goalId;
+    }
+
     public Integer getParticipantId() { return participantId; }
     public Goal setParticipantId(Integer participantId) { this.participantId = participantId; return this; }
 
     public Integer getTemplateId() { return templateId; }
     public Goal setTemplateId(Integer templateId) { this.templateId = templateId; return this; }
+
+    public String getExternalTemplateId(){
+        return GoalTemplate.GAOL_TEMPLATE_ID_PREFIX + templateId;
+    }
+    public void setExternalTemplateId(String externalTemplateId) {
+
+    }
 
     public String getTitle() { return title; }
     public Goal setTitle(String title) { this.title = title; return this; }
@@ -46,4 +66,18 @@ public class Goal {
 
     public Instant getModified() { return modified; }
     public Goal setModified(Instant modified) { this.modified = modified; return this; }
+
+    public static Integer parseExternalGoalId(String templateId) throws ConflictException {
+        Matcher m = PATTERN_GOAL_ID.matcher(Objects.requireNonNull(templateId));
+        if(!m.find()){
+            throw new ConflictException("Invalid goal ID: " + templateId);
+        }
+        try {
+            return Integer.parseInt(m.group(1));
+        } catch (NumberFormatException e) {
+            throw new ConflictException("Invalid goal ID: " + templateId);
+        }
+    }
+
+
 }

--- a/src/main/java/io/redlink/more/data/model/goal/GoalTemplate.java
+++ b/src/main/java/io/redlink/more/data/model/goal/GoalTemplate.java
@@ -1,10 +1,18 @@
 package io.redlink.more.data.model.goal;
 
+import io.redlink.more.data.exception.ConflictException;
+
 import java.time.Instant;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class GoalTemplate {
+    public static final String GAOL_TEMPLATE_ID_PREFIX = "goaltemplate-";
+    private static final Pattern PATTERN_GOAL_TEMPLATE_ID = Pattern.compile("^" + GAOL_TEMPLATE_ID_PREFIX + "(\\d+)$");
+
     private Long studyId;
     private Integer templateId;
     private String title;
@@ -26,6 +34,10 @@ public class GoalTemplate {
 
     public Integer getTemplateId() { return templateId; }
     public GoalTemplate setTemplateId(Integer templateId) { this.templateId = templateId; return this; }
+
+    public String getExternalTemplateId() {
+        return GAOL_TEMPLATE_ID_PREFIX + templateId;
+    }
 
     public String getTitle() { return title; }
     public GoalTemplate setTitle(String title) { this.title = title; return this; }
@@ -71,4 +83,17 @@ public class GoalTemplate {
         this.adherenceCheckIds = adherenceCheckIds != null ? adherenceCheckIds : new HashSet<>();
         return this;
     }
+
+    public static Integer parseExternalTemplateId(String templateId) throws ConflictException {
+        Matcher m = PATTERN_GOAL_TEMPLATE_ID.matcher(Objects.requireNonNull(templateId));
+        if(!m.find()){
+            throw new ConflictException("Invalid template ID: " + templateId);
+        }
+        try {
+            return Integer.parseInt(m.group(1));
+        } catch (NumberFormatException e) {
+            throw new ConflictException("Invalid template ID: " + templateId);
+        }
+    }
+
 }

--- a/src/main/java/io/redlink/more/data/service/goal/GoalService.java
+++ b/src/main/java/io/redlink/more/data/service/goal/GoalService.java
@@ -1,29 +1,45 @@
 package io.redlink.more.data.service.goal;
 
+import io.redlink.more.data.elastic.model.ElasticDataPoint;
 import io.redlink.more.data.exception.BadRequestException;
 import io.redlink.more.data.exception.ConflictException;
+import io.redlink.more.data.model.DataPoint;
 import io.redlink.more.data.model.RoutingInfo;
 import io.redlink.more.data.model.goal.Goal;
 import io.redlink.more.data.model.goal.GoalTemplate;
 import io.redlink.more.data.model.goal.StudyGoalConfig;
 import io.redlink.more.data.repository.GoalRepository;
+import io.redlink.more.data.service.ElasticService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Component
 public class GoalService {
+    private static final Logger log = LoggerFactory.getLogger(GoalService.class);
+
+    public static final String DATA_TYPE_GAOL_CONFIG = "goal-configuration";
 
     private final String PROPERTY_CUSTOM_ADHERENCE_CHECKS_STATE = "custom-adherence-checks-state";
     private final String PROPERTY_CUSTOM_TITLE_STATE = "goal-title-state";
 
     private final GoalRepository goalRepository;
+    private final ElasticService elasticService;
 
-    public GoalService(GoalRepository goalRepository) {
+
+    public GoalService(GoalRepository goalRepository, ElasticService elasticService) {
         this.goalRepository = goalRepository;
+        this.elasticService = elasticService;
     }
 
     @Transactional(readOnly = true)
@@ -42,6 +58,7 @@ public class GoalService {
         return goalRepository.getGoalTemplateById(routingInfo.studyId(), templateId);
     }
 
+    @Transactional(readOnly = false)
     public Goal createGoal(RoutingInfo routingInfo, Goal goal) {
         //we need the goal template to check the adherence checks for the goal
         var template = getGoalTemplate(routingInfo, goal.getTemplateId());
@@ -85,11 +102,38 @@ public class GoalService {
                     goal.getTemplateId(), goal.getAdherenceCheckIds(), template.getStudyId(), template.getTemplateId(),
                     template.getAdherenceCheckIds()));
         }
-        return goalRepository.insertGoal(goal);
+        try {
+            return writeGoalToElastic(goalRepository.insertGoal(goal), template, routingInfo, "CREATE");
+        } catch (IOException ex) {
+            //NOTE: Failing to write the Goal to the Elastic Index will rollback the database as we do not want to have
+            //      goals in the database that are not recorded in the index!
+            log.error("Error while writing {} for action=CREATE to Elastic", goal, ex);
+            throw new IllegalStateException("Unable to create Goal(s) because time series index (elastic) is not available (" +
+                    ex.getClass().getSimpleName() + ": " + ex.getMessage() + ")", ex);
+        }
     }
 
+    @Transactional(readOnly = false)
     public void deleteGoal(RoutingInfo routingInfo, int goalId) {
+        Goal goal = goalRepository.getGoalById(routingInfo.studyId(), goalId);
+        if (goal == null) {
+            return;
+        }
         goalRepository.deleteGoal(routingInfo.studyId(), goalId);
+        GoalTemplate template = goalRepository.getGoalTemplateById(routingInfo.studyId(), goal.getTemplateId());
+        if(template == null) {
+            //NOTE: This should never happen as we have a releational database
+            log.error("Goal template with id {} referenced by {} does not exist", goal.getTemplateId(), goal);
+        }
+        try {
+            writeGoalToElastic(goal, template, routingInfo, "DELETE");
+        } catch (IOException ex) {
+            //NOTE: Failing to write the Goal to the Elastic Index will rollback the database as we do not want to have
+            //      goals in the database that are not recorded in the index!
+            log.error("Error while writing {} for action=DELETE to Elastic", goal, ex);
+            throw new IllegalStateException("Unable to delete Goal(s) because time series index (elastic) is not available (" +
+                    ex.getClass().getSimpleName() + ": " + ex.getMessage() + ")", ex);
+        }
     }
 
     /**
@@ -112,6 +156,31 @@ public class GoalService {
     }
     public Goal getGoal(RoutingInfo routingInfo, int goalId) {
         return goalRepository.getGoalById(routingInfo.studyId(), goalId);
+    }
+
+    private Goal writeGoalToElastic(Goal goal, GoalTemplate template, RoutingInfo routingInfo, String action) throws IOException {
+        DataPoint dataPoint = new DataPoint(
+                UUID.randomUUID().toString(),
+                "%s:%s".formatted(Objects.requireNonNull(goal).getExternalTemplateId(), goal.getExternalGoalId()),
+                template != null ? template.getType() : null,
+                DATA_TYPE_GAOL_CONFIG,
+                Instant.now(),
+                goal.getModified(),
+                toDataMap(goal, Objects.requireNonNull(action)));
+        elasticService.storeDataPoints(List.of(dataPoint), Objects.requireNonNull(routingInfo));
+        return goal;
+    }
+
+    private Map<String, Object> toDataMap(Goal goal, String action) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("action", action);
+        data.put("title", goal.getTitle());
+        data.put("adherence_checks", goal.getAdherenceCheckIds());
+        if(goal.getProperties() instanceof Map<?, ?>) {
+            ((Map<?,?>)goal.getProperties())
+                    .forEach((key,value) -> data.put("property_" + key.toString(), value));
+        }
+        return data;
     }
 
     /**

--- a/src/main/resources/openapi/ExternalAPI.yaml
+++ b/src/main/resources/openapi/ExternalAPI.yaml
@@ -120,6 +120,9 @@ components:
       properties:
         dataId:
           type: string
+        dataType:
+          type: string
+          description: the type of the data value. If missing the type will be set to the observation type
         dataValue:
           type: object
           additionalProperties: true

--- a/src/main/resources/openapi/MobileAppAPI.yaml
+++ b/src/main/resources/openapi/MobileAppAPI.yaml
@@ -397,13 +397,27 @@ components:
           $ref: 'BaseComponents.yaml#/components/schemas/Id'
         observationId:
           type: string
+          pattern: '^[\w-]+(:[\w-]+)?$'
+          description: |
+            The id of the observation. Unique within the context of the current study. The observationId may
+            define two parts separated by a coma. The first refers to the id of the observation. The optional 
+            second part refers to the observation instance. The second part is only present/needed, if the
+            participant can create/configure multiple instances of an observation.
         observationType:
           type: string
+          pattern: '^[\w-]+$'
+          description: the type of the observation
+        dataType:
+          type: string
+          pattern: '^[\w-]+$'
+          description: the type of the dataValue. Needed of a observation type defines data values of different types
         dataValue:
           type: object
+          description: the data of the observation. A JSON object specific to the obserationType and/or dataType
         timestamp:
           type: string
           format: date-time
+          description: the effective time when the observation was recorded
       required:
         - dataId
         - observationId

--- a/src/test/java/io/redlink/more/data/controller/goal/GoalConfigControllerTest.java
+++ b/src/test/java/io/redlink/more/data/controller/goal/GoalConfigControllerTest.java
@@ -141,7 +141,7 @@ class GoalConfigControllerTest {
         mockMvc.perform(get("/goals/api/v1/templates")
                         .with(user(userDetails)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].templateId").value("1"))
+                .andExpect(jsonPath("$[0].templateId").value("goaltemplate-1"))
                 .andExpect(jsonPath("$[0].title").value("Daily Step Goal"))
                 .andExpect(jsonPath("$[0].info").value("Some info"))
                 .andExpect(jsonPath("$[0].type").value("steps"))

--- a/src/test/java/io/redlink/more/data/controller/goal/GoalControllerTest.java
+++ b/src/test/java/io/redlink/more/data/controller/goal/GoalControllerTest.java
@@ -77,8 +77,8 @@ class GoalControllerTest {
                         .with(user(userDetails)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].goalId").value("1"))
-                .andExpect(jsonPath("$[0].templateId").value("101"))
+                .andExpect(jsonPath("$[0].goalId").value("goal-1"))
+                .andExpect(jsonPath("$[0].templateId").value("goaltemplate-101"))
                 .andExpect(jsonPath("$[0].title").value("Daily Step Goal"))
                 .andExpect(jsonPath("$[0].adherenceChecks[0]").value("morning"))
                 .andExpect(jsonPath("$[0].properties.target").value(10000))
@@ -101,8 +101,8 @@ class GoalControllerTest {
         mockMvc.perform(get("/goals/api/v1/goals/5")
                         .with(user(userDetails)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.goalId").value("5"))
-                .andExpect(jsonPath("$.templateId").value("101"))
+                .andExpect(jsonPath("$.goalId").value("goal-5"))
+                .andExpect(jsonPath("$.templateId").value("goaltemplate-101"))
                 .andExpect(jsonPath("$.title").value("Daily Step Goal"))
                 .andExpect(jsonPath("$.adherenceChecks[0]").value("morning"))
                 .andExpect(jsonPath("$.properties.target").value(10000));
@@ -168,7 +168,7 @@ class GoalControllerTest {
         RoutingInfo routingInfo = new RoutingInfo(STUDY_ID, PARTICIPANT_ID, -1, Set.of(), true, true);
         GatewayUserDetails userDetails = new GatewayUserDetails("app-user", "app-user-pwd", Set.of(GatewayUserDetailService.APP_ROLE), routingInfo);
         GoalDataDTO dto1 = new GoalDataDTO()
-                .templateId("101")
+                .templateId("goaltemplate-101")
                 .title("Morning Walk")
                 .adherenceChecks(List.of(AdherenceCheckScheduleEnumDTO.MORNING))
                 .properties(java.util.Map.of("target", 8000));
@@ -183,10 +183,29 @@ class GoalControllerTest {
                         .content(objectMapper.writeValueAsString(List.of(dto1))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
-                .andExpect(jsonPath("$[0].goalId").value("100"))
-                .andExpect(jsonPath("$[0].templateId").value("101"))
+                .andExpect(jsonPath("$[0].goalId").value("goal-100"))
+                .andExpect(jsonPath("$[0].templateId").value("goaltemplate-101"))
                 .andExpect(jsonPath("$[0].title").value("Daily Step Goal"))
                 .andExpect(jsonPath("$[0].adherenceChecks[0]").value("morning"));
+    }
+
+    @Test
+    void goalsCreation_illegalTemplateId() throws Exception {
+        RoutingInfo routingInfo = new RoutingInfo(STUDY_ID, PARTICIPANT_ID, -1, Set.of(), true, true);
+        GatewayUserDetails userDetails = new GatewayUserDetails("app-user", "app-user-pwd", Set.of(GatewayUserDetailService.APP_ROLE), routingInfo);
+        GoalDataDTO dto1 = new GoalDataDTO()
+                .templateId("101") //expected 'goaltemplate-101'
+                .title("Morning Walk")
+                .adherenceChecks(List.of(AdherenceCheckScheduleEnumDTO.MORNING))
+                .properties(java.util.Map.of("target", 8000));
+
+        when(authenticationFacade.assertAuthority(GatewayUserDetailService.APP_ROLE)).thenReturn(userDetails);
+
+        mockMvc.perform(post("/goals/api/v1/goals")
+                        .with(user(userDetails))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(List.of(dto1))))
+                .andExpect(status().isConflict());
     }
 
     // =====================================================================

--- a/src/test/java/io/redlink/more/data/service/ElasticServiceTest.java
+++ b/src/test/java/io/redlink/more/data/service/ElasticServiceTest.java
@@ -7,22 +7,28 @@ import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
+import io.redlink.more.data.elastic.model.ElasticDataPoint;
 import io.redlink.more.data.model.DataPoint;
 import io.redlink.more.data.model.RoutingInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.xml.crypto.Data;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static io.redlink.more.data.util.ElasticUtils.Constants.GARMIN_SUMMARY_ID_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,6 +65,8 @@ class ElasticServiceTest {
         when(dp2.data()).thenReturn(data2);
         when(dp1.datapointId()).thenReturn("1");
         when(dp2.datapointId()).thenReturn("2");
+        when(dp1.observationId()).thenReturn("1");
+        when(dp2.observationId()).thenReturn("1");
 
         List<DataPoint> bulk = List.of(dp1, dp2);
 
@@ -83,11 +91,83 @@ class ElasticServiceTest {
     }
 
     @Test
+    @DisplayName("storeDataPoints with InstanceId: returns successfully stored ids")
+    void storeDataPoints_withInstanceId_returnsIds() throws Exception {
+        var dp1Now = Instant.now();
+        var dp1EffectiveTime = dp1Now.minusSeconds(10);
+        var dp2Now = Instant.now();
+        var dp2EffectiveTime = dp1Now.minusSeconds(5);
+        DataPoint dp1 = new DataPoint(
+                UUID.randomUUID().toString(),
+                "goaltemplate-1:goal-1",
+                "reduce-amount-of",
+                "amount-of",
+                dp1Now,
+                dp1EffectiveTime,
+                Map.of("amount", "5", "unit", "Zigarren"));
+        DataPoint dp2 = new DataPoint(
+                UUID.randomUUID().toString(),
+                "goaltemplate-1:goal-2",
+                "reduce-amount-of",
+                "amount-of",
+                dp2Now,
+                dp2EffectiveTime,
+                Map.of("amount", "15", "unit", "Zigaretten"));
+
+        List<DataPoint> bulk = List.of(dp1, dp2);
+
+        String uidPrefix = "1_10_";
+        BulkResponseItem item1 = mock(BulkResponseItem.class);
+        BulkResponseItem item2 = mock(BulkResponseItem.class);
+        when(item1.id()).thenReturn(uidPrefix + "1");
+        when(item2.id()).thenReturn(uidPrefix + "2");
+        when(item1.error()).thenReturn(null);
+        when(item2.error()).thenReturn(null);
+
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+        when(bulkResponse.errors()).thenReturn(false);
+        when(bulkResponse.items()).thenReturn(List.of(item1, item2));
+
+        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+
+        when(client.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
+
+        List<String> ids = elasticService.storeDataPoints(bulk, routingInfo);
+        assertThat(ids).containsExactlyInAnyOrder("1", "2");
+        verify(client).bulk(bulkRequestCaptor.capture());
+        BulkRequest bulkRequest = bulkRequestCaptor.getValue();
+        assertThat(bulkRequest).isNotNull();
+        assertThat(bulkRequest.operations()).hasSize(2);
+        assertThat(bulkRequest.operations().get(0).index()).isNotNull();
+        assertThat(bulkRequest.operations().get(0).index().document()).isInstanceOf(ElasticDataPoint.class);
+        ElasticDataPoint indexDataPoint1 = (ElasticDataPoint)bulkRequest.operations().get(0).index().document();
+        assertThat(indexDataPoint1.observationId()).isEqualTo("goaltemplate-1");
+        assertThat(indexDataPoint1.instanceId()).isEqualTo("goal-1");
+        assertThat(indexDataPoint1.observationType()).isEqualTo("reduce-amount-of");
+        assertThat(indexDataPoint1.dataType()).isEqualTo("amount-of");
+        assertThat(indexDataPoint1.data()).hasSize(2);
+        assertThat(indexDataPoint1.data().get("amount")).isEqualTo("5");
+        assertThat(indexDataPoint1.data().get("unit")).isEqualTo("Zigarren");
+
+        assertThat(bulkRequest.operations().get(1).index()).isNotNull();
+        assertThat(bulkRequest.operations().get(1).index().document()).isInstanceOf(ElasticDataPoint.class);
+        ElasticDataPoint indexDataPoint2 = (ElasticDataPoint)bulkRequest.operations().get(1).index().document();
+        assertThat(indexDataPoint2.observationId()).isEqualTo("goaltemplate-1");
+        assertThat(indexDataPoint2.instanceId()).isEqualTo("goal-2");
+        assertThat(indexDataPoint2.observationType()).isEqualTo("reduce-amount-of");
+        assertThat(indexDataPoint2.dataType()).isEqualTo("amount-of");
+        assertThat(indexDataPoint2.data()).hasSize(2);
+        assertThat(indexDataPoint2.data().get("amount")).isEqualTo("15");
+        assertThat(indexDataPoint2.data().get("unit")).isEqualTo("Zigaretten");
+    }
+
+    @Test
     @DisplayName("storeDataPoints: stores datapoints without Garmin summary ids")
     void storeDataPoints_storesWithoutGarminSummaryIds() throws Exception {
         DataPoint dp = mock(DataPoint.class);
         when(dp.data()).thenReturn(Map.of("other", "value"));
         when(dp.datapointId()).thenReturn("42");
+        when(dp.observationId()).thenReturn("1");
 
         String uidPrefix = "1_10_";
         BulkResponseItem item = mock(BulkResponseItem.class);
@@ -129,6 +209,7 @@ class ElasticServiceTest {
         DataPoint dp = mock(DataPoint.class);
         when(dp.data()).thenReturn(Map.of());
         when(dp.datapointId()).thenReturn("1");
+        when(dp.observationId()).thenReturn("1");
 
         IOException io = new IOException("boom");
         when(client.bulk(any(BulkRequest.class))).thenThrow(io);


### PR DESCRIPTION
#288: Goal Data Storage

### Features:

* On Goal creation and deletions data points with the dataType `goal-configuration` are written to the Elastic index
* The DataWebservice was extended so that GoalData are written correctly.

See #324 for the specification

### Changes:

* GoalTemplates provided by the GoalConfig controller now use the `goaltemplate-` ID prefix
* Goals provided by the Goal controller now use the `goal-` ID prefix. Also referenced templates do use the `goaltemplate-` ID prefix
* The internal Model classes have new `getExternalId` methods. The normal getter and setter do not use the prefixes
* The DataPoints do no longer set the dataType to the observationType. The Webservice model was extended to include an optional dataType. If this is set it is used. If not the observationType is still set for backward compatibility
* The `observaitonId` now supports `<observation-id>[:<instance-id>]`. The `instance-id` allows to refer a specific observation in cases where participants are allowed to create multiple instances of an observation. This is exactly whats happens for Goals. So if the `observation-id` refers to a goal template the value of the `instance-id` is mapped to the `goal-id`
* The ExternalAPI now also supports a `dataType`. However no Goal Support was added to this API.

### BugFixes:

* Fixed the SecurityConfiguration where the leading `/` was missing for the `/goal/api/v1/**` path
* added the ConflictException to the ControllerExceptionHandler. Now the correct 409 state is returned if this Exception is thrown (was 500)