### PR TITLE
#429: Goal related bug fixes

### DIFF
--- a/src/main/java/io/redlink/more/data/controller/transformer/DataTransformer.java
+++ b/src/main/java/io/redlink/more/data/controller/transformer/DataTransformer.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 public final class DataTransformer {
@@ -34,6 +35,7 @@ public final class DataTransformer {
         return new DataPoint(
                 dataPoint.getDataId(),
                 dataPoint.getObservationId(),
+                dataPoint.getInstanceId(),
                 dataPoint.getObservationType(),
                 StringUtils.isBlank(dataPoint.getDataType()) ? dataPoint.getObservationType() : dataPoint.getDataType(),
                 recordingTime,
@@ -49,14 +51,22 @@ public final class DataTransformer {
                 .toList();
     }
 
+    /**
+     * @deprecated use the String observationId with `{type}_{id}` (e.g. `observation_123`)
+     */
+    @Deprecated
     public static DataPoint createDataPoint(ExternalDataDTO dataPoint, ApiRoutingInfo routingInfo, Instant recordingTime, Integer observationId) {
+        return createDataPoint(dataPoint, routingInfo, recordingTime, "observation_" + Objects.requireNonNull(observationId), null);
+    }
+    public static DataPoint createDataPoint(ExternalDataDTO dataPoint, ApiRoutingInfo routingInfo, Instant recordingTime, String observationId, String instanceId) {
         Instant dateTime = dataPoint.getTimestamp();
         return new DataPoint(
                 UUID.randomUUID().toString(),
-                observationId.toString(),
+                Objects.requireNonNull(observationId),
+                instanceId,
                 routingInfo.observationType(),
                 StringUtils.isBlank(dataPoint.getDataType()) ? routingInfo.observationType(): dataPoint.getDataType(),
-                recordingTime,
+                Objects.requireNonNull(recordingTime),
                 dateTime,
                 dataPoint.getDataValue());
     }

--- a/src/main/java/io/redlink/more/data/elastic/model/ElasticDataPoint.java
+++ b/src/main/java/io/redlink/more/data/elastic/model/ElasticDataPoint.java
@@ -68,11 +68,6 @@ public record ElasticDataPoint(
     }
 
     public static ElasticDataPoint toElastic(DataPoint dataPoint, RoutingInfo elasticInfo) {
-        var observationIdParts = StringUtils.split(dataPoint.observationId(),':');
-        if(observationIdParts.length > 2) { //NOTE: no full validation, just a smoke test
-            throw new IllegalStateException("Illegal formatted observation id: " + dataPoint.observationId() +
-                    "(Expected <observation-id>[:<instance-id>],  Format: ^[\\w-]+(:[\\w-]+)?$");
-        }
         return new ElasticDataPoint(
                 dataPoint.datapointId(),
                 "participant_%d".formatted(elasticInfo.participantId()),
@@ -82,8 +77,8 @@ public record ElasticDataPoint(
                         .findFirst()
                         .orElse(null),
                 //TODO: Do we need observation groups in the Elastic index. I am not sure (westei, 18.12.2025)
-                observationIdParts[0],
-                observationIdParts.length > 1 ? observationIdParts[1] : null,
+                dataPoint.observationId(),
+                dataPoint.instanceId(),
                 dataPoint.observationType(),
                 dataPoint.dataType() == null ? dataPoint.observationType() : dataPoint.dataType(),
                 dataPoint.serverTime(),

--- a/src/main/java/io/redlink/more/data/model/DataPoint.java
+++ b/src/main/java/io/redlink/more/data/model/DataPoint.java
@@ -14,6 +14,7 @@ import java.util.Map;
 public record DataPoint(
         String datapointId,
         String observationId,
+        String instanceId,
         String observationType,
         String dataType,
         Instant serverTime,

--- a/src/main/java/io/redlink/more/data/model/goal/Goal.java
+++ b/src/main/java/io/redlink/more/data/model/goal/Goal.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
 
 public class Goal {
 
-    public static final String GOAL_ID_PREFIX = "goal-";
+    public static final String GOAL_ID_PREFIX = "goal_";
     private static final Pattern PATTERN_GOAL_ID = Pattern.compile("^(?:" + GOAL_ID_PREFIX + ")?(\\d+)$");
 
     private Long studyId;

--- a/src/main/java/io/redlink/more/data/model/goal/GoalTemplate.java
+++ b/src/main/java/io/redlink/more/data/model/goal/GoalTemplate.java
@@ -10,7 +10,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class GoalTemplate {
-    public static final String GOAL_TEMPLATE_ID_PREFIX = "goaltemplate-";
+    public static final String GOAL_TEMPLATE_ID_PREFIX = "goaltemplate_";
     private static final Pattern PATTERN_GOAL_TEMPLATE_ID = Pattern.compile("^" + GOAL_TEMPLATE_ID_PREFIX + "(\\d+)$");
 
     private Long studyId;

--- a/src/main/java/io/redlink/more/data/service/goal/GoalService.java
+++ b/src/main/java/io/redlink/more/data/service/goal/GoalService.java
@@ -167,7 +167,8 @@ public class GoalService {
     private Goal writeGoalToElastic(Goal goal, GoalTemplate template, RoutingInfo routingInfo, String action) throws IOException {
         DataPoint dataPoint = new DataPoint(
                 UUID.randomUUID().toString(),
-                "%s:%s".formatted(Objects.requireNonNull(goal).getExternalTemplateId(), goal.getExternalGoalId()),
+                Objects.requireNonNull(goal).getExternalTemplateId(),
+                Objects.requireNonNull(goal).getExternalGoalId(),
                 template != null ? template.getType() : null,
                 DATA_TYPE_GAOL_CONFIG,
                 Instant.now(),

--- a/src/main/java/io/redlink/more/data/service/observations/limesurvey/LimeSurveyComponent.java
+++ b/src/main/java/io/redlink/more/data/service/observations/limesurvey/LimeSurveyComponent.java
@@ -101,7 +101,7 @@ public class LimeSurveyComponent implements ObservationComponent {
             throw new IllegalArgumentException("Could not find RoutingInfo for LimeSurvey Component for provided parameters");
         }
 
-        if (storeAnswer(surveyId.get(), savedId.get(), token, routingInfo, Integer.toString(resolvedObservationId))) {
+        if (storeAnswer(surveyId.get(), savedId.get(), token, routingInfo, "observation_" + resolvedObservationId)) {
             LOG.debug("Stored LimeSurvey answer for survey {}, token {}, observation {}", surveyId.get(), token, resolvedObservationId);
             return Optional.of(new CallbackResult(routingInfo, resolvedObservationId));
         }
@@ -169,6 +169,7 @@ public class LimeSurveyComponent implements ObservationComponent {
             DataPoint dataPoint = new DataPoint(
                     UUID.randomUUID().toString(),
                     observationId,
+                    null,
                     getObservationType(),
                     getObservationType(),
                     Instant.now(),

--- a/src/main/java/io/redlink/more/data/transformers/garmin/AbstractGarminTransformer.java
+++ b/src/main/java/io/redlink/more/data/transformers/garmin/AbstractGarminTransformer.java
@@ -70,7 +70,8 @@ public abstract class AbstractGarminTransformer {
             return observations.stream().map(observation ->
                             new DataPoint(
                                     uniqueSummaryId(summaryId, dataType, data.timestamp()),
-                                    String.valueOf(observation.observationId()),
+                                    "observation_" + observation.observationId(),
+                                    null,
                                     observation.type(),
                                     dataType.name(),
                                     Instant.now(),

--- a/src/main/resources/openapi/MobileAppAPI.yaml
+++ b/src/main/resources/openapi/MobileAppAPI.yaml
@@ -418,12 +418,14 @@ components:
           $ref: 'BaseComponents.yaml#/components/schemas/Id'
         observationId:
           type: string
-          pattern: '^[\w-]+(:[\w-]+)?$'
+          pattern: '^[\w-]+$'
           description: |
-            The id of the observation. Unique within the context of the current study. The observationId may
-            define two parts separated by a coma. The first refers to the id of the observation. The optional 
-            second part refers to the observation instance. The second part is only present/needed, if the
-            participant can create/configure multiple instances of an observation.
+            The id of the observation. Unique within the context of the current study.
+        instanceId:
+          type: string
+          description: |
+            The id of the instance. Only present if the user can create multiple instance of the same observation
+            and the sent data belongs to one specific of such instances.
         observationType:
           type: string
           pattern: '^[\w-]+$'

--- a/src/test/java/io/redlink/more/data/controller/goal/GoalConfigControllerTest.java
+++ b/src/test/java/io/redlink/more/data/controller/goal/GoalConfigControllerTest.java
@@ -141,7 +141,7 @@ class GoalConfigControllerTest {
         mockMvc.perform(get("/goals/api/v1/templates")
                         .with(user(userDetails)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].templateId").value("goaltemplate-1"))
+                .andExpect(jsonPath("$[0].templateId").value("goaltemplate_1"))
                 .andExpect(jsonPath("$[0].title").value("Daily Step Goal"))
                 .andExpect(jsonPath("$[0].info").value("Some info"))
                 .andExpect(jsonPath("$[0].type").value("steps"))

--- a/src/test/java/io/redlink/more/data/controller/goal/GoalControllerTest.java
+++ b/src/test/java/io/redlink/more/data/controller/goal/GoalControllerTest.java
@@ -77,8 +77,8 @@ class GoalControllerTest {
                         .with(user(userDetails)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].goalId").value("goal-1"))
-                .andExpect(jsonPath("$[0].templateId").value("goaltemplate-101"))
+                .andExpect(jsonPath("$[0].goalId").value("goal_1"))
+                .andExpect(jsonPath("$[0].templateId").value("goaltemplate_101"))
                 .andExpect(jsonPath("$[0].title").value("Daily Step Goal"))
                 .andExpect(jsonPath("$[0].adherenceChecks[0]").value("morning"))
                 .andExpect(jsonPath("$[0].properties.target").value(10000))
@@ -101,8 +101,8 @@ class GoalControllerTest {
         mockMvc.perform(get("/goals/api/v1/goals/5")
                         .with(user(userDetails)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.goalId").value("goal-5"))
-                .andExpect(jsonPath("$.templateId").value("goaltemplate-101"))
+                .andExpect(jsonPath("$.goalId").value("goal_5"))
+                .andExpect(jsonPath("$.templateId").value("goaltemplate_101"))
                 .andExpect(jsonPath("$.title").value("Daily Step Goal"))
                 .andExpect(jsonPath("$.adherenceChecks[0]").value("morning"))
                 .andExpect(jsonPath("$.properties.target").value(10000));
@@ -168,7 +168,7 @@ class GoalControllerTest {
         RoutingInfo routingInfo = new RoutingInfo(STUDY_ID, PARTICIPANT_ID, -1, Set.of(), true, true);
         GatewayUserDetails userDetails = new GatewayUserDetails("app-user", "app-user-pwd", Set.of(GatewayUserDetailService.APP_ROLE), routingInfo);
         GoalDataDTO dto1 = new GoalDataDTO()
-                .templateId("goaltemplate-101")
+                .templateId("goaltemplate_101")
                 .title("Morning Walk")
                 .adherenceChecks(List.of(AdherenceCheckScheduleEnumDTO.MORNING))
                 .properties(java.util.Map.of("target", 8000));
@@ -183,8 +183,8 @@ class GoalControllerTest {
                         .content(objectMapper.writeValueAsString(List.of(dto1))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
-                .andExpect(jsonPath("$[0].goalId").value("goal-100"))
-                .andExpect(jsonPath("$[0].templateId").value("goaltemplate-101"))
+                .andExpect(jsonPath("$[0].goalId").value("goal_100"))
+                .andExpect(jsonPath("$[0].templateId").value("goaltemplate_101"))
                 .andExpect(jsonPath("$[0].title").value("Daily Step Goal"))
                 .andExpect(jsonPath("$[0].adherenceChecks[0]").value("morning"));
     }

--- a/src/test/java/io/redlink/more/data/service/AbstractGarminTransformerTest.java
+++ b/src/test/java/io/redlink/more/data/service/AbstractGarminTransformerTest.java
@@ -60,7 +60,8 @@ class AbstractGarminTransformerTest extends AbstractGarminTransformerTestBase<Ab
             return observations.stream()
                     .map(obs -> new DataPoint(
                             "dp-" + obs.observationId(),
-                            String.valueOf(obs.observationId()),
+                            "observation_" + obs.observationId(),
+                            null,
                             obs.type(),
                             DataType.HEARTRATE.name(),
                             Instant.now(),
@@ -214,7 +215,7 @@ class AbstractGarminTransformerTest extends AbstractGarminTransformerTestBase<Ab
         @SuppressWarnings("unchecked")
         Map<String, Object> storedData = (Map<String, Object>) dataField.get(dataPoint1);
 
-        assertThat(obsId).isEqualTo(observationId);
+        assertThat(obsId).isEqualTo("observation_" + observationId);
         assertThat(obsType).isEqualTo(observationType);
         assertThat(storedDataType).isEqualTo(dataType.name());
         assertThat(storedTimestamp).isEqualTo(timestamp);
@@ -279,7 +280,7 @@ class AbstractGarminTransformerTest extends AbstractGarminTransformerTestBase<Ab
 
         assertThat(result).hasSize(1);
         DataPoint dp = result.get(0);
-        assertThat(dp.observationId()).isEqualTo("1");
+        assertThat(dp.observationId()).isEqualTo("observation_1");
         assertThat(dp.effectiveDateTime()).isBetween(garminStart.minusSeconds(1), garminEnd.plusSeconds(1));
     }
 

--- a/src/test/java/io/redlink/more/data/service/ActivityDataPointTransformerTest.java
+++ b/src/test/java/io/redlink/more/data/service/ActivityDataPointTransformerTest.java
@@ -229,7 +229,8 @@ class ActivityDataPointTransformerTest extends AbstractGarminTransformerTestBase
         // Datapoint representing an ACTIVITY_START inside the range
         DataPoint startPoint = new DataPoint(
                 "dp-start",
-                "1",
+                "observation_1",
+                null,
                 "garmin_epochs",
                 "ACTIVITY_START",
                 Instant.now(),
@@ -240,7 +241,8 @@ class ActivityDataPointTransformerTest extends AbstractGarminTransformerTestBase
         // Datapoint representing an ACTIVITY_END outside the range but linked via START_TIME_KEY
         DataPoint endPoint = new DataPoint(
                 "dp-end",
-                "1",
+                "observation_1",
+                null,
                 "garmin_epochs",
                 "ACTIVITY_END",
                 Instant.now(),
@@ -251,7 +253,8 @@ class ActivityDataPointTransformerTest extends AbstractGarminTransformerTestBase
         // Another datapoint with no overlap at all
         DataPoint unrelated = new DataPoint(
                 "dp-unrelated",
-                "2",
+                "observation_2",
+                null,
                 "garmin_epochs",
                 "ACTIVITY_START",
                 Instant.now(),

--- a/src/test/java/io/redlink/more/data/service/BloodPressureTransformerTest.java
+++ b/src/test/java/io/redlink/more/data/service/BloodPressureTransformerTest.java
@@ -77,7 +77,7 @@ class BloodPressureTransformerTest extends AbstractGarminTransformerTestBase<Blo
 
         assertThat(results).hasSize(1);
         DataPoint dp = results.get(0);
-        assertThat(dp.observationId()).isEqualTo("1");
+        assertThat(dp.observationId()).isEqualTo("observation_1");
         assertThat(dp.dataType()).isEqualTo(DataType.BLOOD_PRESSURE.name());
         assertThat(dp.effectiveDateTime()).isEqualTo(ts);
         assertThat(dp.data()).containsEntry("systolic", 120)
@@ -139,7 +139,7 @@ class BloodPressureTransformerTest extends AbstractGarminTransformerTestBase<Blo
         assertThat(result).hasSize(1);
 
         DataPoint dp = result.get(0);
-        assertThat(dp.observationId()).isEqualTo("42");
+        assertThat(dp.observationId()).isEqualTo("observation_42");
         assertThat(dp.dataType()).isEqualTo(DataType.BLOOD_PRESSURE.name());
         assertThat(dp.effectiveDateTime()).isEqualTo(measurement);
 
@@ -156,8 +156,8 @@ class BloodPressureTransformerTest extends AbstractGarminTransformerTestBase<Blo
     @Test
     @DisplayName("filterDataPointByTimeRange: returns data as-is (no filtering)")
     void filterDataPointByTimeRange_returnsInput() throws Exception {
-        DataPoint dp1 = new DataPoint("id1", "1", "garmin-bp", DataType.BLOOD_PRESSURE.name(), Instant.now(), Instant.now(), Map.of());
-        DataPoint dp2 = new DataPoint("id2", "2", "garmin-bp", DataType.BLOOD_PRESSURE.name(), Instant.now(), Instant.now(), Map.of());
+        DataPoint dp1 = new DataPoint("id1", "observation_1", null, "garmin-bp", DataType.BLOOD_PRESSURE.name(), Instant.now(), Instant.now(), Map.of());
+        DataPoint dp2 = new DataPoint("id2", "observation_2", null, "garmin-bp", DataType.BLOOD_PRESSURE.name(), Instant.now(), Instant.now(), Map.of());
 
         List<DataPoint> input = List.of(dp1, dp2);
         List<DataPoint> out = transformer.exposeFilter(List.of(Range.of(Instant.EPOCH, Instant.now())), input);

--- a/src/test/java/io/redlink/more/data/service/DailyStepDataTransformerTest.java
+++ b/src/test/java/io/redlink/more/data/service/DailyStepDataTransformerTest.java
@@ -80,7 +80,7 @@ class DailyStepDataTransformerTest extends AbstractGarminTransformerTestBase<Dai
         assertThat(result).hasSize(1);
         DataPoint dp = result.get(0);
         assertThat(dp.dataType()).isEqualTo(DataType.DAILY_STEPS.name());
-        assertThat(dp.observationId()).isEqualTo("1");
+        assertThat(dp.observationId()).isEqualTo("observation_1");
         // Effective time is the start of the window
         assertThat(dp.effectiveDateTime()).isEqualTo(start);
 
@@ -96,8 +96,8 @@ class DailyStepDataTransformerTest extends AbstractGarminTransformerTestBase<Dai
     @Test
     @DisplayName("filterDataPointByTimeRange: returns input unchanged (no filtering)")
     void filterDataPointByTimeRange_noFiltering() {
-        DataPoint a = new DataPoint("a", "1", "type", DataType.DAILY_STEPS.name(), Instant.now(), Instant.now(), Map.of());
-        DataPoint b = new DataPoint("b", "1", "type", DataType.DAILY_STEPS.name(), Instant.now(), Instant.now(), Map.of());
+        DataPoint a = new DataPoint("a", "observation_1", null, "type", DataType.DAILY_STEPS.name(), Instant.now(), Instant.now(), Map.of());
+        DataPoint b = new DataPoint("b", "observation_1", null,  "type", DataType.DAILY_STEPS.name(), Instant.now(), Instant.now(), Map.of());
         List<DataPoint> input = List.of(a, b);
 
         List<DataPoint> out = this.transformer.exposeFilterByTimeRange(List.of(Range.of(Instant.EPOCH, Instant.now())), input);

--- a/src/test/java/io/redlink/more/data/service/ElasticServiceTest.java
+++ b/src/test/java/io/redlink/more/data/service/ElasticServiceTest.java
@@ -99,7 +99,8 @@ class ElasticServiceTest {
         var dp2EffectiveTime = dp1Now.minusSeconds(5);
         DataPoint dp1 = new DataPoint(
                 UUID.randomUUID().toString(),
-                "goaltemplate-1:goal-1",
+                "goaltemplate_1",
+                "goal_1",
                 "reduce-amount-of",
                 "amount-of",
                 dp1Now,
@@ -107,7 +108,8 @@ class ElasticServiceTest {
                 Map.of("amount", "5", "unit", "Zigarren"));
         DataPoint dp2 = new DataPoint(
                 UUID.randomUUID().toString(),
-                "goaltemplate-1:goal-2",
+                "goaltemplate_1",
+                "goal_2",
                 "reduce-amount-of",
                 "amount-of",
                 dp2Now,
@@ -141,8 +143,8 @@ class ElasticServiceTest {
         assertThat(bulkRequest.operations().get(0).index()).isNotNull();
         assertThat(bulkRequest.operations().get(0).index().document()).isInstanceOf(ElasticDataPoint.class);
         ElasticDataPoint indexDataPoint1 = (ElasticDataPoint)bulkRequest.operations().get(0).index().document();
-        assertThat(indexDataPoint1.observationId()).isEqualTo("goaltemplate-1");
-        assertThat(indexDataPoint1.instanceId()).isEqualTo("goal-1");
+        assertThat(indexDataPoint1.observationId()).isEqualTo("goaltemplate_1");
+        assertThat(indexDataPoint1.instanceId()).isEqualTo("goal_1");
         assertThat(indexDataPoint1.observationType()).isEqualTo("reduce-amount-of");
         assertThat(indexDataPoint1.dataType()).isEqualTo("amount-of");
         assertThat(indexDataPoint1.data()).hasSize(2);
@@ -152,8 +154,8 @@ class ElasticServiceTest {
         assertThat(bulkRequest.operations().get(1).index()).isNotNull();
         assertThat(bulkRequest.operations().get(1).index().document()).isInstanceOf(ElasticDataPoint.class);
         ElasticDataPoint indexDataPoint2 = (ElasticDataPoint)bulkRequest.operations().get(1).index().document();
-        assertThat(indexDataPoint2.observationId()).isEqualTo("goaltemplate-1");
-        assertThat(indexDataPoint2.instanceId()).isEqualTo("goal-2");
+        assertThat(indexDataPoint2.observationId()).isEqualTo("goaltemplate_1");
+        assertThat(indexDataPoint2.instanceId()).isEqualTo("goal_2");
         assertThat(indexDataPoint2.observationType()).isEqualTo("reduce-amount-of");
         assertThat(indexDataPoint2.dataType()).isEqualTo("amount-of");
         assertThat(indexDataPoint2.data()).hasSize(2);

--- a/src/test/java/io/redlink/more/data/service/EpochStepDataTransformerTest.java
+++ b/src/test/java/io/redlink/more/data/service/EpochStepDataTransformerTest.java
@@ -76,7 +76,7 @@ class EpochStepDataTransformerTest extends AbstractGarminTransformerTestBase<Epo
         assertThat(result).hasSize(1);
         DataPoint dp = result.get(0);
         assertThat(dp.dataType()).isEqualTo(DataType.EPOCH_STEPS.name());
-        assertThat(dp.observationId()).isEqualTo("1");
+        assertThat(dp.observationId()).isEqualTo("observation_1");
         assertThat(dp.effectiveDateTime()).isEqualTo(start);
 
         Map<String, Object> data = dp.data();
@@ -88,8 +88,8 @@ class EpochStepDataTransformerTest extends AbstractGarminTransformerTestBase<Epo
     @Test
     @DisplayName("filterDataPointByTimeRange: returns input unchanged (no filtering)")
     void filterDataPointByTimeRange_noFiltering() {
-        DataPoint a = new DataPoint("a", "1", "type", DataType.EPOCH_STEPS.name(), Instant.now(), Instant.now(), Map.of());
-        DataPoint b = new DataPoint("b", "1", "type", DataType.EPOCH_STEPS.name(), Instant.now(), Instant.now(), Map.of());
+        DataPoint a = new DataPoint("a", "observation_1", null, "type", DataType.EPOCH_STEPS.name(), Instant.now(), Instant.now(), Map.of());
+        DataPoint b = new DataPoint("b", "observation_1", null, "type", DataType.EPOCH_STEPS.name(), Instant.now(), Instant.now(), Map.of());
         List<DataPoint> input = List.of(a, b);
 
         List<DataPoint> out = transformer.exposeFilterByTimeRange(List.of(Range.of(Instant.EPOCH, Instant.now())), input);

--- a/src/test/java/io/redlink/more/data/service/HeartRateTransformersTest.java
+++ b/src/test/java/io/redlink/more/data/service/HeartRateTransformersTest.java
@@ -80,7 +80,7 @@ class HeartRateTransformersTest extends AbstractGarminTransformerTestBase<HeartR
 
         DataPoint result = results.get(0);
         assertThat(result).isNotNull();
-        assertThat(result.observationId()).isEqualTo(String.valueOf(observationId));
+        assertThat(result.observationId()).isEqualTo("observation_" + observationId);
         assertThat(result.observationType()).isEqualTo(observationType);
         assertThat(result.dataType()).isEqualTo(dataType.name());
         assertThat(result.effectiveDateTime()).isEqualTo(timestamp);
@@ -102,7 +102,8 @@ class HeartRateTransformersTest extends AbstractGarminTransformerTestBase<HeartR
 
         DataPoint inRange = new DataPoint(
                 "dp-1",
-                "1",
+                "observation_1",
+                null,
                 "garmin-heartrate-type",
                 DataType.HEARTRATE.name(),
                 Instant.now(),
@@ -112,7 +113,8 @@ class HeartRateTransformersTest extends AbstractGarminTransformerTestBase<HeartR
 
         DataPoint outOfRange = new DataPoint(
                 "dp-2",
-                "2",
+                "observation_2",
+                null,
                 "garmin-heartrate-type",
                 DataType.HEARTRATE.name(),
                 Instant.now(),
@@ -138,7 +140,8 @@ class HeartRateTransformersTest extends AbstractGarminTransformerTestBase<HeartR
 
         DataPoint outOfRange1 = new DataPoint(
                 "dp-1",
-                "1",
+                "observation_1",
+                null,
                 "garmin-heartrate-type",
                 DataType.HEARTRATE.name(),
                 Instant.now(),
@@ -148,7 +151,8 @@ class HeartRateTransformersTest extends AbstractGarminTransformerTestBase<HeartR
 
         DataPoint outOfRange2 = new DataPoint(
                 "dp-2",
-                "2",
+                "observation_2",
+                null,
                 "garmin-heartrate-type",
                 DataType.HEARTRATE.name(),
                 Instant.now(),

--- a/src/test/java/io/redlink/more/data/service/SleepDataTransformerTest.java
+++ b/src/test/java/io/redlink/more/data/service/SleepDataTransformerTest.java
@@ -200,6 +200,7 @@ class SleepDataTransformerTest extends AbstractGarminTransformerTestBase<SleepDa
                 null,
                 null,
                 null,
+                null,
                 dataType.dataType,
                 effectiveTime,
                 effectiveTime,

--- a/src/test/java/io/redlink/more/data/util/DataUtilsTest.java
+++ b/src/test/java/io/redlink/more/data/util/DataUtilsTest.java
@@ -18,7 +18,7 @@ class DataUtilsTest {
         Instant end = Instant.parse("2023-01-01T11:00:00Z");
         Instant effective = Instant.parse("2023-01-01T10:30:00Z");
 
-        DataPoint dp = new DataPoint("id", "obsId", "obsType", "dataType", Instant.now(), effective,
+        DataPoint dp = new DataPoint("id", "obsId", null, "obsType", "dataType", Instant.now(), effective,
                 Map.of("startTime", start.toString(), "endTime", end.toString()));
 
         Range<Instant> range = DataUtils.buildRangeFromDataPoint(dp);
@@ -32,7 +32,7 @@ class DataUtilsTest {
         Instant end = Instant.parse("2023-01-01T11:00:00Z");
         Instant effective = Instant.parse("2023-01-01T11:30:00Z");
 
-        DataPoint dp = new DataPoint("id", "obsId", "obsType", "dataType", Instant.now(), effective,
+        DataPoint dp = new DataPoint("id", "obsId", null, "obsType", "dataType", Instant.now(), effective,
                 Map.of("startTime", start.toString(), "endTime", end.toString()));
 
         Range<Instant> range = DataUtils.buildRangeFromDataPoint(dp);
@@ -45,7 +45,7 @@ class DataUtilsTest {
         Instant start = Instant.parse("2023-01-01T10:00:00Z");
         Instant effective = Instant.parse("2023-01-01T11:00:00Z");
 
-        DataPoint dp = new DataPoint("id", "obsId", "obsType", "dataType", Instant.now(), effective,
+        DataPoint dp = new DataPoint("id", "obsId", null, "obsType", "dataType", Instant.now(), effective,
                 Map.of("startTime", start.toString()));
 
         Range<Instant> range = DataUtils.buildRangeFromDataPoint(dp);
@@ -57,7 +57,7 @@ class DataUtilsTest {
     void testBuildRangeFromDataPoint_OnlyEffective() {
         Instant effective = Instant.parse("2023-01-01T11:00:00Z");
 
-        DataPoint dp = new DataPoint("id", "obsId", "obsType", "dataType", Instant.now(), effective, Map.of());
+        DataPoint dp = new DataPoint("id", "obsId", null, "obsType", "dataType", Instant.now(), effective, Map.of());
 
         Range<Instant> range = DataUtils.buildRangeFromDataPoint(dp);
         assertEquals(effective, range.getMinimum());
@@ -68,7 +68,7 @@ class DataUtilsTest {
     void testBuildRangeFromDataPoint_OnlyStartNoEffective() {
         Instant start = Instant.parse("2023-01-01T10:00:00Z");
 
-        DataPoint dp = new DataPoint("id", "obsId", "obsType", "dataType", Instant.now(), null,
+        DataPoint dp = new DataPoint("id", "obsId", null, "obsType", "dataType", Instant.now(), null,
                 Map.of("startTime", start.toString()));
 
         Range<Instant> range = DataUtils.buildRangeFromDataPoint(dp);
@@ -78,7 +78,7 @@ class DataUtilsTest {
 
     @Test
     void testBuildRangeFromDataPoint_NoTimeData() {
-        DataPoint dp = new DataPoint("id", "obsId", "obsType", "dataType", Instant.now(), null, Map.of());
+        DataPoint dp = new DataPoint("id", "obsId", null, "obsType", "dataType", Instant.now(), null, Map.of());
         assertThrows(IllegalArgumentException.class, () -> DataUtils.buildRangeFromDataPoint(dp));
     }
 }


### PR DESCRIPTION
* goaltemplate and goal ids now use `_`
* API update to parse `instanceId` explicitly
* related Model changes
    * required a lot of adaptations is classes that use this record
* changed several places to use the new `observation_{id}` instead of the now deprecated `{id}`
    * also adapted the unit tests accordingly